### PR TITLE
fix: added slack webhook signature verification and integrate it into the slack endpoint

### DIFF
--- a/src/slack-verify.ts
+++ b/src/slack-verify.ts
@@ -1,53 +1,62 @@
 import { createHmac, timingSafeEqual } from 'node:crypto'
 
-const MAX_REQUEST_AGE_SECONDS = 5 * 60 // 5 minutes — reject stale/replayed requests
+const MAX_REQUEST_AGE_SECONDS = 300 // 5 minutes
 
 export interface VerifyResult {
     valid: boolean
     error?: string
 }
 
-/**
- * Verify a Slack webhook request signature.
- *
- * @param signingSecret - Your app's Signing Secret from api.slack.com
- * @param timestamp     - Value of the `x-slack-request-timestamp` header
- * @param rawBody       - The raw request body string (must be the exact bytes Slack sent)
- * @param signature     - Value of the `x-slack-signature` header (format: `v0=...`)
- */
+
 export function verifySlackSignature(
     signingSecret: string,
     timestamp: string | undefined,
     rawBody: string,
     signature: string | undefined
 ): VerifyResult {
-    // Guard: missing headers
-    if (!signature || !timestamp) {
-        return { valid: false, error: 'Missing signature or timestamp headers' }
+    if (!timestamp) {
+        return { valid: false, error: 'Missing timestamp header' }
     }
 
-    // Guard: replay attack — reject requests older than 5 minutes
-    const requestAge = Math.abs(Math.floor(Date.now() / 1000) - parseInt(timestamp, 10))
-    if (isNaN(requestAge) || requestAge > MAX_REQUEST_AGE_SECONDS) {
+    if (!signature) {
+        return { valid: false, error: 'Missing signature header' }
+    }
+
+    const ts = parseInt(timestamp, 10)
+
+    if (isNaN(ts)) {
+        return { valid: false, error: 'Invalid timestamp' }
+    }
+
+    const now = Math.floor(Date.now() / 1000)
+    const requestAge = now - ts
+
+    // Reject future timestamps (clock skew / manipulation)
+    if (requestAge < 0) {
+        return { valid: false, error: 'Invalid timestamp' }
+    }
+
+    // Reject stale requests (replay protection)
+    if (requestAge > MAX_REQUEST_AGE_SECONDS) {
         return { valid: false, error: 'Request too old' }
     }
 
-    // Compute expected signature: v0=HMAC-SHA256(secret, "v0:{ts}:{body}")
-    const baseString = `v0:${timestamp}:${rawBody}`
+    // Compute expected signature
+    const sigBasestring = `v0:${timestamp}:${rawBody}`
     const expectedSignature = 'v0=' + createHmac('sha256', signingSecret)
-        .update(baseString)
+        .update(sigBasestring)
         .digest('hex')
 
     // Constant-time comparison to prevent timing attacks
     try {
-        const sigBuffer = Buffer.from(signature, 'utf8')
-        const expectedBuffer = Buffer.from(expectedSignature, 'utf8')
+        const expected = Buffer.from(expectedSignature, 'utf8')
+        const actual = Buffer.from(signature, 'utf8')
 
-        if (sigBuffer.length !== expectedBuffer.length) {
+        if (expected.length !== actual.length) {
             return { valid: false, error: 'Invalid signature' }
         }
 
-        if (!timingSafeEqual(sigBuffer, expectedBuffer)) {
+        if (!timingSafeEqual(expected, actual)) {
             return { valid: false, error: 'Invalid signature' }
         }
     } catch {


### PR DESCRIPTION
This pull request adds robust verification for incoming Slack webhook requests to improve security and prevent forged or replayed events. It introduces a new `verifySlackSignature` function, ensures the raw request body is available for verification, and adds comprehensive tests for the new logic.

**Slack webhook signature verification:**

* Added a new `verifySlackSignature` utility in `src/slack-verify.ts` that checks Slack request signatures, rejects stale or replayed requests, and uses constant-time comparison to prevent timing attacks.
* Updated the Slack webhook route in `src/index.ts` to call `verifySlackSignature` and reject invalid requests with a 401 error, logging the reason for failures.
* Registered a custom Fastify content type parser in `src/index.ts` to capture the raw request body, which is required for signature verification.
* Imported the new verification logic in the main server entrypoint.

**Testing:**

* Added a test suite in `src/slack-verify.test.ts` covering valid signatures, invalid signatures, stale requests, and missing headers to ensure the verification logic is robust.

Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Slack webhook requests now require signature verification to prevent unauthorized access.
  * Implemented replay attack protection by rejecting requests older than 5 minutes.

* **Tests**
  * Added comprehensive test coverage for Slack signature verification, including valid signatures, invalid signatures, expired requests, and missing headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->