### PR TITLE
feat: complete #11 Bengaluru ride fare comparison behavior

### DIFF
--- a/src/cognitive.ts
+++ b/src/cognitive.ts
@@ -81,6 +81,7 @@ Today is ${today} (${dayName}). Always convert relative dates ("next Friday", "t
 
 STEP 1 — Call a tool if the user needs real-time data:
 - Flights, hotels, weather, places, currency, transport → those tools
+- Cab/auto/bike fare comparisons in Bengaluru (Ola/Uber/Rapido/Namma Yatri) → compare_rides
 - "Best deal", "compare platforms", "order or go out?", "which app is cheaper" → compare_prices_proactive
 - Food delivery comparison (Swiggy vs Zomato, restaurant prices, coupons) → compare_food_prices
 - Grocery prices, quick delivery apps in general → compare_grocery_prices

--- a/src/tools/ride-compare.test.ts
+++ b/src/tools/ride-compare.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { compareRides } from './ride-compare.js'
+
+const ORIGINAL_GOOGLE_KEY = process.env.GOOGLE_PLACES_API_KEY
+const ORIGINAL_OPENWEATHER_KEY = process.env.OPENWEATHERMAP_API_KEY
+
+function mockJsonResponse(body: unknown, ok = true): Response {
+    return {
+        ok,
+        status: ok ? 200 : 500,
+        statusText: ok ? 'OK' : 'Internal Server Error',
+        json: async () => body,
+    } as Response
+}
+
+describe('compareRides', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks()
+        vi.unstubAllGlobals()
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date('2026-02-23T07:00:00.000Z')) // 12:30 IST (no time surge)
+
+        process.env.GOOGLE_PLACES_API_KEY = 'test-google-key'
+        delete process.env.OPENWEATHERMAP_API_KEY
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+        vi.unstubAllGlobals()
+
+        if (ORIGINAL_GOOGLE_KEY === undefined) delete process.env.GOOGLE_PLACES_API_KEY
+        else process.env.GOOGLE_PLACES_API_KEY = ORIGINAL_GOOGLE_KEY
+
+        if (ORIGINAL_OPENWEATHER_KEY === undefined) delete process.env.OPENWEATHERMAP_API_KEY
+        else process.env.OPENWEATHERMAP_API_KEY = ORIGINAL_OPENWEATHER_KEY
+    })
+
+    it('returns a configuration error when Google key is missing', async () => {
+        delete process.env.GOOGLE_PLACES_API_KEY
+
+        const result = await compareRides({ origin: 'Koramangala', destination: 'Whitefield' })
+
+        expect(result.success).toBe(false)
+        expect(result.error).toContain('Google Places API key is missing')
+    })
+
+    it('applies rain surge (1.5-2.0x heuristic midpoint) on Ola/Uber when Bengaluru weather indicates rain', async () => {
+        process.env.OPENWEATHERMAP_API_KEY = 'test-openweather-key'
+
+        const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+            const url = String(input)
+            if (url.includes('distancematrix')) {
+                return mockJsonResponse({
+                    rows: [{
+                        elements: [{
+                            status: 'OK',
+                            distance: { value: 10000 },
+                            duration: { value: 1200, text: '20 mins' },
+                        }],
+                    }],
+                })
+            }
+
+            if (url.includes('openweathermap.org')) {
+                return mockJsonResponse({
+                    cod: 200,
+                    name: 'Bengaluru',
+                    sys: { country: 'IN' },
+                    main: { temp: 24, feels_like: 25, humidity: 82 },
+                    wind: { speed: 2.2 },
+                    weather: [{ main: 'Rain', description: 'light rain' }],
+                })
+            }
+
+            throw new Error(`Unexpected URL: ${url}`)
+        })
+        vi.stubGlobal('fetch', fetchMock)
+
+        const result = await compareRides({ origin: 'Koramangala', destination: 'Whitefield' })
+
+        expect(result.success).toBe(true)
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+
+        const data = result.data as {
+            formatted: string
+            raw: { surgeMultiplier: number; surgeNotes: string[] }
+        }
+        expect(data.raw.surgeMultiplier).toBe(1.7)
+        expect(data.raw.surgeNotes.join(' ')).toContain('Rain detected in Bengaluru')
+        expect(data.formatted).toContain('Rain detected in Bengaluru')
+        expect(data.formatted).toContain('💡 Cheapest enclosed: Rapido Auto (₹170)')
+    })
+
+    it('applies evening time surge when weather surge is unavailable', async () => {
+        vi.setSystemTime(new Date('2026-02-23T13:00:00.000Z')) // 18:30 IST
+
+        const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+            const url = String(input)
+            if (url.includes('distancematrix')) {
+                return mockJsonResponse({
+                    rows: [{
+                        elements: [{
+                            status: 'OK',
+                            distance: { value: 10000 },
+                            duration: { value: 1200, text: '20 mins' },
+                        }],
+                    }],
+                })
+            }
+            throw new Error(`Unexpected URL: ${url}`)
+        })
+        vi.stubGlobal('fetch', fetchMock)
+
+        const result = await compareRides({ origin: 'Koramangala', destination: 'Whitefield' })
+
+        expect(result.success).toBe(true)
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+
+        const data = result.data as {
+            formatted: string
+            raw: { surgeMultiplier: number; surgeNotes: string[] }
+        }
+        expect(data.raw.surgeMultiplier).toBe(1.4)
+        expect(data.raw.surgeNotes.join(' ')).toContain('Evening rush')
+        expect(data.formatted).toContain('Evening rush (5-8PM)')
+    })
+})


### PR DESCRIPTION
## Summary
- complete `compare_rides` behavior for issue #11 with Bengaluru fare cards and Distance Matrix route estimates
- add rain-aware surge heuristic (1.5-2.0x range modeled with midpoint) for Ola/Uber
- preserve time-of-day surge behavior and include structured `surgeNotes` in raw output
- improve classifier routing prompt so Bengaluru cab/auto/bike fare queries map to `compare_rides`
- add focused tests for missing key, rain surge, and evening surge scenarios

## Verification
- `npx -y node@20 ./node_modules/vitest/vitest.mjs run`
- `npx -y node@20 ./node_modules/typescript/bin/tsc -p tsconfig.json`

Closes #11


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ride comparison tool for Bengaluru cabs, autos, and bikes is now available.
  * Surge pricing now accounts for weather conditions (rain) and time of day.
  * Multiple surge factors are displayed for pricing transparency.

* **Tests**
  * Added comprehensive test coverage for ride comparison functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->