### PR TITLE
Make proactive stimuli location-aware; add live location presence and generalize city context

### DIFF
--- a/config/SOUL.md
+++ b/config/SOUL.md
@@ -1,7 +1,7 @@
 ---
 name: Aria
 tagline: Your city companion — food, rides, places, real info
-version: 7.0
+version: 8.0
 ---
 
 ## 1. Core Identity
@@ -156,12 +156,13 @@ Examples:
 
 Use these to tune suggestions without asking:
 
-- Rain confirmed → lead with delivery options, mention traffic
-- 7–9am or 5–8pm weekday → factor in peak traffic, adjust travel estimates
+- Rain confirmed → lead with delivery/indoor options, mention commute impact
+- Typical peak commute windows (weekday morning/evening) → factor traffic delays
 - Friday evening → higher energy, nightlife and dining context appropriate
 - Weekend morning → brunch, cafes, relaxed pace
 - User mentions quick/efficient → prioritise speed and convenience
 - User mentions "hidden gem" or "new place" → avoid mainstream chains
+- If user city is unknown, say that clearly and give broadly useful suggestions
 
 
 ---
@@ -194,6 +195,20 @@ Instead:
 
 
 ---
+
+
+## 10.5 Constructive Contradiction Policy
+
+Aria can disagree when it helps the user.
+
+- Contradict only for user benefit: safety, cost/time waste, factual mismatch, or obvious better alternatives
+- Keep contradiction respectful and short: one clear reason + one better option
+- Use evidence when available (live prices, ETA, weather, opening hours, events)
+- Never be combative or dismissive
+- If user insists after a contradiction, acknowledge and support their choice
+
+Example shape:
+- "That plan will be rough in rain + surge right now. Better move: [alternative]."
 
 ## 11. What Aria Can Actually Do
 

--- a/docs/proactive-agent-gap-analysis.md
+++ b/docs/proactive-agent-gap-analysis.md
@@ -1,0 +1,53 @@
+# Proactive Agent Gap Analysis
+
+## Goal reviewed
+Target behavior: an always-on proactive companion that consumes external stimuli (weather/traffic/festivals), uses friend-graph context for group planning, and can both act autonomously and stay engaging (including constructive pushback) during active conversations.
+
+## Current blockers in the codebase
+
+1. **Stimulus engines are city-locked and not user-personalized.**
+   - Weather stimulus always calls `getWeather({ location: 'Bengaluru' })`.
+   - Traffic stimulus uses fixed Bengaluru corridors + fixed test routes.
+   - Festival suggestions are Bengaluru-centric and hardcoded by date.
+   - Result: users outside Bengaluru (or with different home city/travel context) get irrelevant triggers.
+
+2. **Stimulus-to-action is delayed and coarse-grained.**
+   - Scheduler refreshes weather/traffic every 30 minutes and festivals every 6 hours.
+   - This cadence is too slow for "rain just started", sudden congestion, or short-lived event opportunities.
+
+3. **Proactive sends are explicitly blocked while user is active.**
+   - Smart gate exits when recent user activity < 30 minutes.
+   - Each stimulus sender also skips when inactivity < 60 minutes.
+   - Result: the system does not do in-conversation proactive assistance; it mostly runs as re-engagement after silence.
+
+4. **Group planning pipeline detects intent correlation, but does not execute planning tools.**
+   - Squad intent detection is regex-category based.
+   - Social outbound builds/sends action cards from correlated categories.
+   - It does not chain `search_places`/`compare_*`/`directions` to produce concrete multi-option plans and deal-aware recommendations for the full group.
+
+5. **Friend/squad graph usage is mostly command-driven, not conversationally autonomous.**
+   - Friend/squad operations are triggered via `/friend` and `/squad` command parsing in the main handler.
+   - There is no natural-language friend-graph orchestration pass (e.g., "plan this for my squad") that auto-invokes graph-aware planning workflows.
+
+6. **Critical proactive state remains in-memory with restart sensitivity.**
+   - Proactive user registry and cooldown maps are process-local maps.
+   - Architecture docs also call out in-process cache/state constraints.
+   - Result: behavior consistency drops on restart and across multi-instance deployments, weakening "always-on" proactive behavior.
+
+7. **Constructive contradiction is incidental, not policy-driven.**
+   - Mood engine includes a "devil" mode but only as a weighted tone blend.
+   - No explicit disagreement policy (when to challenge, evidence threshold, safety bounds, or user preference controls) is wired into planning/execution.
+
+## Practical impact on your requested behavior
+
+- The agent is currently better at **periodic nudges** than **continuous proactive co-pilot behavior**.
+- It can surface social signals, but not yet convert them into **end-to-end autonomous group trip planning** with dynamic options/deals.
+- It does not yet robustly support **real-time multi-stimulus orchestration during active chat**.
+
+## High-priority fix order
+
+1. Personalize stimuli by user home city/current location and squad context.
+2. Introduce an in-conversation proactive lane (non-intrusive helper actions while user is chatting).
+3. Upgrade squad pipeline from "correlated intent card" to "tool-chained group planner".
+4. Move proactive orchestration state to durable/shared storage (or Redis).
+5. Add explicit contradiction policy (when/how to push back with evidence).

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
   type ChannelMessage
 } from './channels.js'
 import { pendingLocationStore, reverseGeocode } from './location.js'
+import { setLiveUserLocation } from './location-presence.js'
 
 // Type augmentation for raw body on Slack requests
 declare module 'fastify' {
@@ -283,6 +284,7 @@ server.post('/webhook/telegram', async (request, reply) => {
       const address = await reverseGeocode(latitude, longitude)
       const user = await getOrCreateUser('telegram', userId)
       await saveUserLocation(user.userId, address)
+      setLiveUserLocation(userId, { address, lat: latitude, lng: longitude, source: 'gps' })
 
       const pending = pendingLocationStore.get(userId)
       pendingLocationStore.delete(userId)

--- a/src/location-presence.test.ts
+++ b/src/location-presence.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { getLiveUserLocation, setLiveUserLocation } from './location-presence.js'
+
+describe('location-presence', () => {
+  it('stores and returns live user location', () => {
+    setLiveUserLocation('u-1', {
+      address: 'Koramangala, Bengaluru',
+      lat: 12.93,
+      lng: 77.62,
+      source: 'gps',
+    })
+
+    const row = getLiveUserLocation('u-1')
+    expect(row).not.toBeNull()
+    expect(row?.address).toContain('Koramangala')
+    expect(row?.source).toBe('gps')
+  })
+})

--- a/src/location-presence.ts
+++ b/src/location-presence.ts
@@ -1,0 +1,37 @@
+/**
+ * Live user location presence (in-memory)
+ *
+ * Tracks recently shared GPS-derived location so proactive flows can prefer
+ * current context over stale profile home_location.
+ */
+
+export interface LiveUserLocation {
+  address: string
+  lat: number
+  lng: number
+  source: 'gps'
+  updatedAt: number
+}
+
+const liveLocationByChannelUserId = new Map<string, LiveUserLocation>()
+const LIVE_LOCATION_TTL_MS = 6 * 60 * 60 * 1000 // 6h freshness window
+
+export function setLiveUserLocation(
+  channelUserId: string,
+  location: Omit<LiveUserLocation, 'updatedAt'>,
+): void {
+  liveLocationByChannelUserId.set(channelUserId, {
+    ...location,
+    updatedAt: Date.now(),
+  })
+}
+
+export function getLiveUserLocation(channelUserId: string): LiveUserLocation | null {
+  const row = liveLocationByChannelUserId.get(channelUserId)
+  if (!row) return null
+  if (Date.now() - row.updatedAt > LIVE_LOCATION_TTL_MS) {
+    liveLocationByChannelUserId.delete(channelUserId)
+    return null
+  }
+  return row
+}

--- a/src/media/proactiveRunner.ts
+++ b/src/media/proactiveRunner.ts
@@ -33,10 +33,11 @@ import { sendMediaViaPipeline } from './mediaDownloader.js'
 import { sendProactiveContent } from '../channels.js'
 import { sleep } from '../tools/scrapers/retry.js'
 import { expireStaleIntentFunnels, tryStartIntentDrivenFunnel } from '../proactive-intent/index.js'
-import { getWeatherState, type WeatherStimulusKind } from '../weather/weather-stimulus.js'
-import { getTrafficState, trafficMessage, trafficHashtag } from '../stimulus/traffic-stimulus.js'
-import { getFestivalState, festivalMessage, festivalHashtag } from '../stimulus/festival-stimulus.js'
+import { getWeatherState, refreshWeatherState, type WeatherStimulusKind } from '../weather/weather-stimulus.js'
+import { getTrafficState, refreshTrafficState, trafficMessage, trafficHashtag } from '../stimulus/traffic-stimulus.js'
+import { getFestivalState, refreshFestivalState, festivalMessage, festivalHashtag } from '../stimulus/festival-stimulus.js'
 import { getActiveRejections } from '../intelligence/rejection-memory.js'
+import { getLiveUserLocation } from '../location-presence.js'
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -358,13 +359,15 @@ async function trySendWeatherStimulus(
     userId: string,
     chatId: string,
     state: UserProactiveState,
+    location: string,
 ): Promise<boolean> {
-    const weather = getWeatherState()
+    await refreshWeatherState(location).catch(() => null)
+    const weather = getWeatherState(location)
     if (!weather?.stimulus) return false
 
     const lastActivity = userLastActivity.get(userId) ?? 0
     const inactivityMins = lastActivity > 0 ? (Date.now() - lastActivity) / 60_000 : Infinity
-    if (lastActivity > 0 && inactivityMins < 60) return false
+    if (lastActivity > 0 && inactivityMins < 15) return false
 
     const prev = weatherStimulusSentAt.get(userId)
     if (
@@ -419,13 +422,15 @@ async function trySendTrafficStimulus(
     userId: string,
     chatId: string,
     state: UserProactiveState,
+    location: string,
 ): Promise<boolean> {
-    const traffic = getTrafficState()
+    await refreshTrafficState(location).catch(() => null)
+    const traffic = getTrafficState(location)
     if (!traffic?.stimulus || traffic.stimulus === 'CLEAR_TRAFFIC') return false
 
     const lastActivity = userLastActivity.get(userId) ?? 0
     const inactivityMins = lastActivity > 0 ? (Date.now() - lastActivity) / 60_000 : Infinity
-    if (lastActivity > 0 && inactivityMins < 60) return false
+    if (lastActivity > 0 && inactivityMins < 15) return false
 
     const last = trafficStimulusSentAt.get(userId) ?? 0
     if (Date.now() - last < TRAFFIC_STIMULUS_COOLDOWN_MS) return false
@@ -462,13 +467,15 @@ async function trySendFestivalStimulus(
     userId: string,
     chatId: string,
     state: UserProactiveState,
+    location: string,
 ): Promise<boolean> {
-    const festival = getFestivalState()
+    await refreshFestivalState(location).catch(() => null)
+    const festival = getFestivalState(location)
     if (!festival?.active || !festival.festival) return false
 
     const lastActivity = userLastActivity.get(userId) ?? 0
     const inactivityMins = lastActivity > 0 ? (Date.now() - lastActivity) / 60_000 : Infinity
-    if (lastActivity > 0 && inactivityMins < 60) return false
+    if (lastActivity > 0 && inactivityMins < 15) return false
 
     const prev = festivalStimulusSentAt.get(userId)
     if (prev && prev.festival === festival.festival.name && Date.now() - prev.ts < FESTIVAL_STIMULUS_COOLDOWN_MS) return false
@@ -499,8 +506,26 @@ async function trySendFestivalStimulus(
 
 // ─── Main: Run Proactive for One User ───────────────────────────────────────
 
+async function resolveUserHomeLocation(channelUserId: string): Promise<string> {
+    const live = getLiveUserLocation(channelUserId)
+    if (live?.address) {
+        return live.address
+    }
+
+    try {
+        const { rows } = await getPool().query<{ home_location: string | null }>(
+            `SELECT home_location FROM users WHERE channel = 'telegram' AND channel_user_id = $1 LIMIT 1`,
+            [channelUserId],
+        )
+        return (rows[0]?.home_location ?? '').trim() || 'Bengaluru'
+    } catch {
+        return 'Bengaluru'
+    }
+}
+
 async function runProactiveForUser(userId: string, chatId: string): Promise<void> {
     const state = await getOrCreateState(userId, chatId)
+    const homeLocation = await resolveUserHomeLocation(userId)
 
     // Smart adaptive gate check
     const gate = computeSmartGate(state)
@@ -510,7 +535,7 @@ async function runProactiveForUser(userId: string, chatId: string): Promise<void
     }
 
     // Stimulus priority: Weather > Traffic > Festival (per CLAUDE.md)
-    const weatherSent = await trySendWeatherStimulus(userId, chatId, state).catch(err => {
+    const weatherSent = await trySendWeatherStimulus(userId, chatId, state, homeLocation).catch(err => {
         console.warn(`[Proactive] Weather stimulus failed for ${userId}:`, (err as Error)?.message)
         return false
     })
@@ -519,7 +544,7 @@ async function runProactiveForUser(userId: string, chatId: string): Promise<void
         return
     }
 
-    const trafficSent = await trySendTrafficStimulus(userId, chatId, state).catch(err => {
+    const trafficSent = await trySendTrafficStimulus(userId, chatId, state, homeLocation).catch(err => {
         console.warn(`[Proactive] Traffic stimulus failed for ${userId}:`, (err as Error)?.message)
         return false
     })
@@ -528,7 +553,7 @@ async function runProactiveForUser(userId: string, chatId: string): Promise<void
         return
     }
 
-    const festivalSent = await trySendFestivalStimulus(userId, chatId, state).catch(err => {
+    const festivalSent = await trySendFestivalStimulus(userId, chatId, state, homeLocation).catch(err => {
         console.warn(`[Proactive] Festival stimulus failed for ${userId}:`, (err as Error)?.message)
         return false
     })

--- a/src/personality.ts
+++ b/src/personality.ts
@@ -34,7 +34,7 @@ import { formatMemoriesForPrompt } from './memory-store.js'
 import { formatGraphForPrompt } from './graph-memory.js'
 import { selectResponseTone } from './cognitive.js'
 import { computeMoodWeights, getMoodInstruction } from './character/mood-engine.js'
-import { getBangaloreContext } from './utils/bangalore-context.js'
+import { getCityContext } from './utils/bangalore-context.js'
 import { selectStrategy, formatStrategyForPrompt } from './influence-engine.js'
 import { formatAgendaForPrompt } from './agenda-planner/formatter.js'
 
@@ -292,9 +292,9 @@ export function composeSystemPrompt(opts: ComposeOptions): string {
     }
 
     // ─── Layer 7c: Bangalore time/traffic context ─────────────────
-    const bangaloreCtx = getBangaloreContext()
-    if (bangaloreCtx) {
-        sections.push(`## City Context\n${bangaloreCtx}`)
+    const cityCtx = getCityContext(opts.homeLocation)
+    if (cityCtx) {
+        sections.push(`## City Context\n${cityCtx}`)
     }
 
     const shouldInjectProactiveGreetingDirective =

--- a/src/stimulus/festival-stimulus.ts
+++ b/src/stimulus/festival-stimulus.ts
@@ -30,6 +30,7 @@ export interface FestivalEvent {
 }
 
 export interface FestivalStimulusState {
+    location: string
     active: boolean
     festival: FestivalEvent | null
     stimulus: FestivalStimulusKind | null
@@ -158,7 +159,16 @@ function festivalCalendar(): FestivalEvent[] {
 
 // ─── In-memory state ──────────────────────────────────────────────────────────
 
+const DEFAULT_LOCATION = 'your city'
+const stateByLocation = new Map<string, FestivalStimulusState>()
+
+function normLocation(location?: string): string {
+    const v = (location ?? DEFAULT_LOCATION).trim()
+    return v.length > 0 ? v : DEFAULT_LOCATION
+}
+
 let currentState: FestivalStimulusState = {
+    location: DEFAULT_LOCATION,
     active: false,
     festival: null,
     stimulus: null,
@@ -166,8 +176,8 @@ let currentState: FestivalStimulusState = {
     updatedAt: 0,
 }
 
-export function getFestivalState(): FestivalStimulusState {
-    return currentState
+export function getFestivalState(location = DEFAULT_LOCATION): FestivalStimulusState {
+    return stateByLocation.get(normLocation(location)) ?? currentState
 }
 
 // ─── Date helpers ─────────────────────────────────────────────────────────────
@@ -220,7 +230,8 @@ async function fetchCalendarificEvents(): Promise<FestivalEvent[]> {
  * Refresh festival stimulus state.
  * Called by scheduler every 6 hours (low frequency — festivals don't change intraday).
  */
-export async function refreshFestivalState(): Promise<FestivalStimulusState> {
+export async function refreshFestivalState(location = DEFAULT_LOCATION): Promise<FestivalStimulusState> {
+    const loc = normLocation(location)
     const today = todayIST()
 
     // Merge hardcoded + API events
@@ -241,12 +252,14 @@ export async function refreshFestivalState(): Promise<FestivalStimulusState> {
 
     if (!nearestFestival || nearestDays > 5) {
         currentState = {
+            location: loc,
             active: false,
             festival: nearestFestival,
             stimulus: null,
             daysUntil: nearestDays,
             updatedAt: Date.now(),
         }
+        stateByLocation.set(loc, currentState)
         return currentState
     }
 
@@ -256,6 +269,7 @@ export async function refreshFestivalState(): Promise<FestivalStimulusState> {
     else stimulus = 'FESTIVAL_LEADUP'
 
     currentState = {
+        location: loc,
         active: true,
         festival: nearestFestival,
         stimulus,
@@ -263,8 +277,10 @@ export async function refreshFestivalState(): Promise<FestivalStimulusState> {
         updatedAt: Date.now(),
     }
 
+    stateByLocation.set(loc, currentState)
+
     console.log(
-        `[FestivalStimulus] ${nearestFestival.name} in ${nearestDays} day(s) → ${stimulus}`
+        `[FestivalStimulus] ${loc}: ${nearestFestival.name} in ${nearestDays} day(s) → ${stimulus}`
     )
 
     return currentState
@@ -277,19 +293,20 @@ export function festivalMessage(state: FestivalStimulusState): string | null {
 
     const { name, suggestions } = state.festival ?? { name: '', suggestions: [] }
     const suggestion = suggestions[Math.floor(Math.random() * suggestions.length)]
+    const localSuggestion = String(suggestion).replace(/Bengaluru/gi, state.location).replace(/Bangalore/gi, state.location)
 
     switch (state.stimulus) {
         case 'FESTIVAL_DAY':
-            return `Happy ${name}! 🎉 Perfect day for — ${suggestion}. Want me to find something near you?`
+            return `Happy ${name}! 🎉 Perfect day for — ${localSuggestion}. Want me to find something near you?`
         case 'FESTIVAL_EVE':
-            return `${name} is tomorrow! 🎊 Time to plan — ${suggestion}. Want suggestions?`
+            return `${name} is tomorrow! 🎊 Time to plan — ${localSuggestion}. Want suggestions?`
         case 'FESTIVAL_LEADUP':
-            return `${name} is in ${state.daysUntil} days 🗓️ Good time to plan — ${suggestion}. Shall I look up options?`
+            return `${name} is in ${state.daysUntil} days 🗓️ Good time to plan — ${localSuggestion}. Shall I look up options?`
         default:
             return null
     }
 }
 
 export function festivalHashtag(state: FestivalStimulusState): string {
-    return state.festival?.hashtag ?? 'bangalorefestival'
+    return state.festival?.hashtag ?? 'festivalplans'
 }

--- a/src/stimulus/traffic-stimulus.ts
+++ b/src/stimulus/traffic-stimulus.ts
@@ -1,44 +1,37 @@
 /**
- * Traffic Stimulus Engine — Issue #91
+ * Traffic Stimulus Engine
  *
- * Checks traffic conditions for Bengaluru and exposes a stimulus state
- * for proactive messaging. When traffic is bad, Aria suggests staying
- * in, ordering delivery, or visiting nearby spots.
- *
- * Primary: Google Maps Distance Matrix API (if TRAFFIC_API_KEY is set)
- * Fallback: Heuristic based on time-of-day and Bengaluru traffic patterns
- *            from src/utils/bangalore-context.ts
+ * Location-aware traffic stimulus with:
+ *  - API path (Google Distance Matrix) for requested city
+ *  - Heuristic fallback based on local time windows
  */
 
-// ─── Types ────────────────────────────────────────────────────────────────────
-
 export type TrafficStimulusKind =
-    | 'HEAVY_TRAFFIC'      // Peak-hour gridlock — suggest delivery/local
-    | 'MODERATE_TRAFFIC'   // Slower than usual — light suggestion
-    | 'CLEAR_TRAFFIC'      // Good conditions — go out suggestion
+    | 'HEAVY_TRAFFIC'
+    | 'MODERATE_TRAFFIC'
+    | 'CLEAR_TRAFFIC'
 
 export interface TrafficStimulusState {
+    location: string
     severity: 'heavy' | 'moderate' | 'clear'
-    durationMinutes: number      // estimated delay vs normal
-    affectedCorridors: string[]  // e.g. ['ORR', 'Silk Board', 'Hebbal flyover']
+    durationMinutes: number
+    affectedCorridors: string[]
     stimulus: TrafficStimulusKind | null
     source: 'api' | 'heuristic'
     updatedAt: number
 }
 
-// ─── In-memory state ──────────────────────────────────────────────────────────
+const DEFAULT_LOCATION = 'Bengaluru'
+const stateByLocation = new Map<string, TrafficStimulusState>()
 
-let currentState: TrafficStimulusState | null = null
-
-export function getTrafficState(): TrafficStimulusState | null {
-    return currentState
+function normLocation(location?: string): string {
+    const v = (location ?? DEFAULT_LOCATION).trim()
+    return v.length > 0 ? v : DEFAULT_LOCATION
 }
 
-// ─── Bengaluru peak-traffic heuristic ────────────────────────────────────────
-
-// Known peak corridors in Bengaluru
-const PEAK_CORRIDORS = ['ORR', 'Silk Board junction', 'KR Puram', 'Hebbal flyover', 'Electronic City flyover']
-const MODERATE_CORRIDORS = ['MG Road', 'Marathahalli', 'Whitefield', 'Jayanagar 4th Block']
+function isBengaluru(location: string): boolean {
+    return /bengaluru|bangalore|blr/i.test(location)
+}
 
 function getIST(): Date {
     const now = new Date()
@@ -46,24 +39,35 @@ function getIST(): Date {
     return new Date(istMs)
 }
 
-function heuristicTrafficState(): TrafficStimulusState {
+function heuristicTrafficState(location: string): TrafficStimulusState {
     const ist = getIST()
     const hour = ist.getHours()
     const isWeekend = [0, 6].includes(ist.getDay())
 
+    const cityCorridors = isBengaluru(location)
+        ? {
+            peak: ['ORR', 'Silk Board', 'KR Puram', 'Hebbal'],
+            moderate: ['MG Road', 'Marathahalli', 'Whitefield'],
+        }
+        : {
+            peak: ['major arterial roads', 'city center corridors'],
+            moderate: ['commercial zones', 'inner ring roads'],
+        }
+
     if (isWeekend) {
-        // Weekends: lighter traffic except late nights near MG Road / Koramangala
         if (hour >= 20 && hour <= 23) {
             return {
+                location,
                 severity: 'moderate',
                 durationMinutes: 15,
-                affectedCorridors: ['MG Road', 'Koramangala 80 feet road'],
+                affectedCorridors: cityCorridors.moderate,
                 stimulus: 'MODERATE_TRAFFIC',
                 source: 'heuristic',
                 updatedAt: Date.now(),
             }
         }
         return {
+            location,
             severity: 'clear',
             durationMinutes: 0,
             affectedCorridors: [],
@@ -73,15 +77,15 @@ function heuristicTrafficState(): TrafficStimulusState {
         }
     }
 
-    // Weekday peak: 7:30–10am, 5:30–9pm
     const morningPeak = hour >= 7 && hour < 10
     const eveningPeak = hour >= 17 && hour < 21
 
     if (morningPeak || eveningPeak) {
         return {
+            location,
             severity: 'heavy',
-            durationMinutes: morningPeak ? 40 : 50,
-            affectedCorridors: PEAK_CORRIDORS,
+            durationMinutes: morningPeak ? 35 : 45,
+            affectedCorridors: cityCorridors.peak,
             stimulus: 'HEAVY_TRAFFIC',
             source: 'heuristic',
             updatedAt: Date.now(),
@@ -90,9 +94,10 @@ function heuristicTrafficState(): TrafficStimulusState {
 
     if ((hour >= 10 && hour < 12) || (hour >= 21 && hour < 23)) {
         return {
+            location,
             severity: 'moderate',
-            durationMinutes: 20,
-            affectedCorridors: MODERATE_CORRIDORS,
+            durationMinutes: 18,
+            affectedCorridors: cityCorridors.moderate,
             stimulus: 'MODERATE_TRAFFIC',
             source: 'heuristic',
             updatedAt: Date.now(),
@@ -100,6 +105,7 @@ function heuristicTrafficState(): TrafficStimulusState {
     }
 
     return {
+        location,
         severity: 'clear',
         durationMinutes: 0,
         affectedCorridors: [],
@@ -109,26 +115,15 @@ function heuristicTrafficState(): TrafficStimulusState {
     }
 }
 
-// ─── Google Maps Traffic API ──────────────────────────────────────────────────
-
-const DEFAULT_LAT = process.env.DEFAULT_LAT ?? '12.9716'
-const DEFAULT_LNG = process.env.DEFAULT_LNG ?? '77.5946'
-
-// Key test routes across Bengaluru to measure traffic conditions
-const TEST_ROUTES = [
-    { origin: '12.9279,77.6271', destination: '12.9698,77.7499', label: 'Koramangala→Whitefield' },
-    { origin: '12.9716,77.5946', destination: '12.8399,77.6770', label: 'Center→Electronic City' },
-]
-
-async function fetchGoogleTrafficCondition(): Promise<TrafficStimulusState | null> {
+async function fetchGoogleTrafficCondition(location: string): Promise<TrafficStimulusState | null> {
     const apiKey = process.env.TRAFFIC_API_KEY ?? process.env.GOOGLE_MAPS_API_KEY
     if (!apiKey) return null
 
     try {
-        const route = TEST_ROUTES[0]
         const url = new URL('https://maps.googleapis.com/maps/api/distancematrix/json')
-        url.searchParams.set('origins', route.origin)
-        url.searchParams.set('destinations', route.destination)
+        // Same-city route probe gives a lightweight congestion signal
+        url.searchParams.set('origins', location)
+        url.searchParams.set('destinations', location)
         url.searchParams.set('departure_time', 'now')
         url.searchParams.set('traffic_model', 'best_guess')
         url.searchParams.set('key', apiKey)
@@ -140,29 +135,22 @@ async function fetchGoogleTrafficCondition(): Promise<TrafficStimulusState | nul
         const element = data?.rows?.[0]?.elements?.[0]
         if (!element || element.status !== 'OK') return null
 
-        const normalDuration = element.duration?.value ?? 0      // seconds
+        const normalDuration = element.duration?.value ?? 0
         const inTrafficDuration = element.duration_in_traffic?.value ?? normalDuration
-        const delaySeconds = inTrafficDuration - normalDuration
-        const delayMinutes = Math.round(delaySeconds / 60)
+        const delayMinutes = Math.round((inTrafficDuration - normalDuration) / 60)
 
-        let severity: 'heavy' | 'moderate' | 'clear'
-        let stimulus: TrafficStimulusKind
-
-        if (delayMinutes >= 20) {
-            severity = 'heavy'
-            stimulus = 'HEAVY_TRAFFIC'
-        } else if (delayMinutes >= 8) {
-            severity = 'moderate'
-            stimulus = 'MODERATE_TRAFFIC'
-        } else {
-            severity = 'clear'
-            stimulus = 'CLEAR_TRAFFIC'
-        }
+        let severity: 'heavy' | 'moderate' | 'clear' = 'clear'
+        let stimulus: TrafficStimulusKind = 'CLEAR_TRAFFIC'
+        if (delayMinutes >= 20) { severity = 'heavy'; stimulus = 'HEAVY_TRAFFIC' }
+        else if (delayMinutes >= 8) { severity = 'moderate'; stimulus = 'MODERATE_TRAFFIC' }
 
         return {
+            location,
             severity,
-            durationMinutes: delayMinutes,
-            affectedCorridors: severity === 'heavy' ? PEAK_CORRIDORS : MODERATE_CORRIDORS,
+            durationMinutes: Math.max(0, delayMinutes),
+            affectedCorridors: isBengaluru(location)
+                ? (severity === 'heavy' ? ['ORR', 'Silk Board'] : ['MG Road', 'Whitefield'])
+                : ['city center'],
             stimulus,
             source: 'api',
             updatedAt: Date.now(),
@@ -172,44 +160,37 @@ async function fetchGoogleTrafficCondition(): Promise<TrafficStimulusState | nul
     }
 }
 
-// ─── Refresh ──────────────────────────────────────────────────────────────────
-
-/**
- * Refresh traffic state. Called by scheduler every 30 minutes.
- * Falls back to heuristic if Google API unavailable.
- */
-export async function refreshTrafficState(): Promise<TrafficStimulusState> {
-    const apiState = await fetchGoogleTrafficCondition().catch(() => null)
-    currentState = apiState ?? heuristicTrafficState()
-    console.log(
-        `[TrafficStimulus] severity=${currentState.severity} ` +
-        `delay=${currentState.durationMinutes}m source=${currentState.source}`
-    )
-    return currentState
+export async function refreshTrafficState(location = DEFAULT_LOCATION): Promise<TrafficStimulusState> {
+    const key = normLocation(location)
+    const apiState = await fetchGoogleTrafficCondition(key).catch(() => null)
+    const state = apiState ?? heuristicTrafficState(key)
+    stateByLocation.set(key, state)
+    return state
 }
 
-// ─── Proactive message helpers ────────────────────────────────────────────────
+export function getTrafficState(location = DEFAULT_LOCATION): TrafficStimulusState | null {
+    return stateByLocation.get(normLocation(location)) ?? null
+}
 
 export function trafficMessage(state: TrafficStimulusState): string {
     const corridors = state.affectedCorridors.slice(0, 2).join(' + ')
-
     switch (state.stimulus) {
         case 'HEAVY_TRAFFIC':
-            return `Traffic is rough right now — ${corridors} is crawling (${state.durationMinutes}min delay). Best to stay in or order delivery. Want options near you?`
+            return `Traffic is rough in ${state.location} — ${corridors || 'major roads'} are slow (${state.durationMinutes}min delay). Better to stay local or order in.`
         case 'MODERATE_TRAFFIC':
-            return `Traffic's a bit slow around ${corridors}. If you're heading out, maybe give it 30 minutes. Want a nearby spot instead?`
+            return `Traffic is a bit slow in ${state.location} (${corridors || 'key corridors'}). If heading out, waiting ~30 mins might help.`
         case 'CLEAR_TRAFFIC':
-            return `Roads are clear right now — good time to head out! Want a spot suggestion?`
+            return `Roads look clear in ${state.location} right now — good window to head out.`
         default:
-            return `Traffic update: roads are ${state.severity} right now. Plan accordingly?`
+            return `Traffic update for ${state.location}: ${state.severity}.`
     }
 }
 
 export function trafficHashtag(state: TrafficStimulusState): string {
     switch (state.stimulus) {
-        case 'HEAVY_TRAFFIC': return 'bangaloredelivery'
-        case 'MODERATE_TRAFFIC': return 'bangalorecafe'
-        case 'CLEAR_TRAFFIC': return 'bangaloreweekend'
-        default: return 'bangalorefood'
+        case 'HEAVY_TRAFFIC': return 'deliverydeals'
+        case 'MODERATE_TRAFFIC': return 'localcafe'
+        case 'CLEAR_TRAFFIC': return 'cityhangouts'
+        default: return 'foodandplans'
     }
 }

--- a/src/utils/bangalore-context.test.ts
+++ b/src/utils/bangalore-context.test.ts
@@ -30,7 +30,7 @@ describe('getProactiveSuggestionQuery', () => {
   it('falls back to Bengaluru when location is missing', () => {
     const now = new Date('2026-03-03T08:00:00Z') // Tuesday 13:30 IST
     const result = getProactiveSuggestionQuery(undefined, now)
-    expect(result.location).toBe('Bengaluru')
+    expect(result.location).toBe('your area')
     expect(result.openNow).toBe(true)
   })
 })

--- a/src/utils/bangalore-context.ts
+++ b/src/utils/bangalore-context.ts
@@ -1,53 +1,66 @@
 /**
- * Bangalore time/traffic context — pure function, zero cost.
- * Injected into every non-simple system prompt so the 70B can
- * naturally weave in city-aware commentary without being told to.
+ * City context helpers — location-aware and not Bangalore-only.
+ *
+ * File name is kept for backward compatibility with existing imports.
  */
 
 export interface ProactiveSuggestionQuery {
-    /** Search intent sent to `search_places`. */
     query: string
-    /** User area (or Bengaluru fallback) for localized suggestions. */
     location: string
-    /** Whether results should prefer currently open places. */
     openNow: boolean
-    /** Named slot used for prompt hinting and observability. */
     moodTag: string
 }
 
-/** Return "now" in IST so all time buckets stay deterministic and testable. */
 function getIstNow(now: Date = new Date()): Date {
     return new Date(now.toLocaleString('en-US', { timeZone: 'Asia/Kolkata' }))
 }
 
-export function getBangaloreContext(): string {
+function isBengaluru(location?: string | null): boolean {
+    const v = (location ?? '').toLowerCase()
+    return /bengaluru|bangalore|blr|koramangala|indiranagar|whitefield|hsr|jayanagar/.test(v)
+}
+
+export function getCityContext(location?: string | null): string {
     const now = getIstNow()
     const h = now.getHours()
-    const day = now.getDay() // 0=Sun, 6=Sat
+    const day = now.getDay()
     const isWeekend = day === 0 || day === 6
+    const place = (location ?? 'their city').trim()
 
     if (h >= 22 || h < 6) {
-        return 'Late night in Bangalore. Most restaurants are closed. Only suggest 24hr options or delivery apps.'
+        return `Late-night window in ${place}. Prioritize open-now places, delivery, and safe commute options.`
     }
-    if (h >= 8 && h <= 10 && !isWeekend) {
-        return 'Morning peak hour in Bangalore. ORR, Silk Board, and Hebbal are heavily congested. Add 30-45 mins to any commute estimate.'
+
+    if (!isWeekend && h >= 7 && h <= 10) {
+        if (isBengaluru(location)) {
+            return 'Weekday morning peak in Bengaluru. ORR/Silk Board/Hebbal often run slow; account for commute buffers.'
+        }
+        return `Weekday morning peak in ${place}. Factor commute buffers and recommend nearby options first.`
     }
-    if (h >= 17 && h <= 20 && !isWeekend) {
-        return 'Evening peak in Bangalore. Silk Board and KR Puram are parking lots right now. Suggest metro or delivery over going out if relevant.'
+
+    if (!isWeekend && h >= 17 && h <= 20) {
+        if (isBengaluru(location)) {
+            return 'Weekday evening peak in Bengaluru. Traffic tends to spike on major corridors; suggest metro/nearby plans when relevant.'
+        }
+        return `Weekday evening rush in ${place}. Prefer closer options and mention transit/traffic tradeoffs.`
     }
+
     if (h >= 12 && h <= 14) {
-        return 'Lunch hour in Bangalore. Good time to suggest quick bites, darshini specials, or delivery deals.'
+        return `Lunch window in ${place}. Suggest efficient lunch picks, quick service, or delivery deals.`
     }
+
     if (isWeekend && h >= 10 && h <= 20) {
-        return 'Weekend in Bangalore. Brunch spots and 12th Main are buzzing. Brewery energy picks up after 3pm.'
+        return `Weekend social window in ${place}. Brunch/cafes earlier, experiences and hangouts later.`
     }
+
     return ''
 }
 
-/**
- * Build a time-aware starter query for post-onboarding proactive suggestions.
- * Used when the user just shared their area and Aria needs a specific, data-backed opener.
- */
+// Backwards-compatible alias used in existing code.
+export function getBangaloreContext(location?: string | null): string {
+    return getCityContext(location)
+}
+
 export function getProactiveSuggestionQuery(
     homeLocation?: string | null,
     now: Date = new Date()
@@ -56,68 +69,28 @@ export function getProactiveSuggestionQuery(
     const h = ist.getHours()
     const day = ist.getDay()
     const isWeekend = day === 0 || day === 6
-    const location = (homeLocation || 'Bengaluru').trim()
+    const location = (homeLocation || 'your area').trim()
 
     if (h >= 22 || h < 6) {
-        return {
-            query: 'late night food and dessert spots',
-            location,
-            openNow: true,
-            moodTag: 'late_night',
-        }
+        return { query: 'late night food, dessert, or open-now hangout spots', location, openNow: true, moodTag: 'late_night' }
     }
     if (!isWeekend && h === 6) {
-        return {
-            query: 'early morning filter coffee and darshini breakfast spots',
-            location,
-            openNow: true,
-            moodTag: 'early_morning',
-        }
+        return { query: 'early morning filter coffee and breakfast spots', location, openNow: true, moodTag: 'early_morning' }
     }
     if (isWeekend && h >= 10 && h <= 14) {
-        return {
-            query: 'popular brunch cafes',
-            location,
-            openNow: true,
-            moodTag: 'weekend_brunch',
-        }
+        return { query: 'popular weekend brunch cafes', location, openNow: true, moodTag: 'weekend_brunch' }
     }
     if (isWeekend && h >= 15 && h <= 21) {
-        return {
-            query: 'trending breweries and evening hangout spots',
-            location,
-            openNow: true,
-            moodTag: 'weekend_evening',
-        }
+        return { query: 'trending evening hangout spots', location, openNow: true, moodTag: 'weekend_evening' }
     }
     if (!isWeekend && h >= 7 && h <= 10) {
-        return {
-            query: 'quick breakfast places',
-            location,
-            openNow: true,
-            moodTag: 'weekday_morning',
-        }
+        return { query: 'quick breakfast or takeaway places', location, openNow: true, moodTag: 'weekday_morning' }
     }
     if (h >= 12 && h <= 14) {
-        return {
-            query: 'lunch spots with good ratings',
-            location,
-            openNow: true,
-            moodTag: 'lunch',
-        }
+        return { query: 'highly rated lunch spots', location, openNow: true, moodTag: 'lunch' }
     }
     if (!isWeekend && h >= 17 && h <= 21) {
-        return {
-            query: 'dinner places and chill evening cafes',
-            location,
-            openNow: true,
-            moodTag: 'weekday_evening',
-        }
+        return { query: 'dinner places and chill evening cafes', location, openNow: true, moodTag: 'weekday_evening' }
     }
-    return {
-        query: 'popular cafes and places to hang out',
-        location,
-        openNow: true,
-        moodTag: 'default',
-    }
+    return { query: 'popular cafes and things to do nearby', location, openNow: true, moodTag: 'default' }
 }

--- a/src/weather/weather-stimulus.ts
+++ b/src/weather/weather-stimulus.ts
@@ -1,7 +1,7 @@
 /**
  * Weather Stimulus Engine
  *
- * Polls OpenWeatherMap periodically and exposes a lightweight weather state
+ * Polls OpenWeatherMap and exposes a lightweight weather state per location
  * for proactive messaging + in-conversation strategy shaping.
  */
 
@@ -26,8 +26,15 @@ export interface WeatherStimulusState {
     updatedAt: number
 }
 
-let currentState: WeatherStimulusState | null = null
-let wasRaining = false
+const DEFAULT_LOCATION = 'Bengaluru'
+const stateByLocation = new Map<string, WeatherStimulusState>()
+const wasRainingByLocation = new Map<string, boolean>()
+
+function normLocation(location?: string): string {
+    const safe = typeof location === 'string' ? location : DEFAULT_LOCATION
+    const v = safe.trim()
+    return v.length > 0 ? v : DEFAULT_LOCATION
+}
 
 function getIST(date: Date): Date {
     return new Date(date.toLocaleString('en-US', { timeZone: 'Asia/Kolkata' }))
@@ -38,6 +45,7 @@ function detectStimulus(
     condition: string,
     isRaining: boolean,
     istHour: number,
+    wasRaining: boolean,
 ): WeatherStimulusKind | null {
     if (isRaining && !wasRaining) return 'RAIN_START'
     if (isRaining) return 'RAIN_HEAVY'
@@ -49,28 +57,29 @@ function detectStimulus(
     return null
 }
 
-/**
- * Refresh in-memory weather context (non-fatal on failure).
- */
-export async function refreshWeatherState(now: Date = new Date()): Promise<WeatherStimulusState | null> {
-    const result = await getWeather({ location: 'Bengaluru' }).catch(() => null)
+export async function refreshWeatherState(locationOrNow: string | Date = DEFAULT_LOCATION, now: Date = new Date()): Promise<WeatherStimulusState | null> {
+    const location = locationOrNow instanceof Date ? DEFAULT_LOCATION : locationOrNow
+    const effectiveNow = locationOrNow instanceof Date ? locationOrNow : now
+    const key = normLocation(location)
+    const result = await getWeather({ location: key }).catch(() => null)
     if (!result?.success || !result.data || typeof result.data !== 'object') {
-        return currentState
+        return stateByLocation.get(key) ?? null
     }
 
     const raw = (result.data as { raw?: any }).raw
-    if (!raw || typeof raw !== 'object') return currentState
+    if (!raw || typeof raw !== 'object') return stateByLocation.get(key) ?? null
 
     const temp = Math.round(Number(raw.main?.temp ?? 0))
     const condition = String(raw.weather?.[0]?.description ?? '').trim()
-    const city = String(raw.name ?? 'Bengaluru')
+    const city = String(raw.name ?? key)
     const isRaining = /rain|drizzle|thunder|shower/i.test(condition)
-    const istNow = getIST(now)
+    const istNow = getIST(effectiveNow)
     const istHour = istNow.getHours()
     const isWeekend = [0, 6].includes(istNow.getDay())
-    const stimulus = detectStimulus(temp, condition, isRaining, istHour)
+    const wasRaining = wasRainingByLocation.get(key) ?? false
+    const stimulus = detectStimulus(temp, condition, isRaining, istHour, wasRaining)
 
-    currentState = {
+    const state: WeatherStimulusState = {
         city,
         temperatureC: temp,
         condition,
@@ -80,12 +89,12 @@ export async function refreshWeatherState(now: Date = new Date()): Promise<Weath
         stimulus,
         updatedAt: Date.now(),
     }
-    wasRaining = isRaining
+    stateByLocation.set(key, state)
+    wasRainingByLocation.set(key, isRaining)
 
-    return currentState
+    return state
 }
 
-export function getWeatherState(): WeatherStimulusState | null {
-    return currentState
+export function getWeatherState(location = DEFAULT_LOCATION): WeatherStimulusState | null {
+    return stateByLocation.get(normLocation(location)) ?? null
 }
-


### PR DESCRIPTION
### Motivation
- Make proactive messaging and in-conversation recommendations respect the user's real-time or profile location instead of being hardcoded to Bengaluru.
- Prefer recently shared GPS as transient presence so proactive flows use fresh context over stale profile `home_location`.
- Reduce overly conservative gating so in-conversation proactive assistance can run sooner, and broaden city-specific context utilities beyond Bangalore.
- Add a short policy for safe, constructive pushback in the persona (`Constructive Contradiction Policy`).

### Description
- Added an in-memory live location presence store `src/location-presence.ts` with `setLiveUserLocation` and `getLiveUserLocation`, and a unit test `src/location-presence.test.ts` exercising storage/lookup.
- Wired GPS shares in the Telegram webhook to call `setLiveUserLocation` in `src/index.ts` so recent shares influence proactive behavior.
- Refactored proactive runner (`src/media/proactiveRunner.ts`) to resolve a user's effective location via `resolveUserHomeLocation` (live GPS -> DB `home_location` -> fallback), pass that to `refresh*State` calls, and lowered the recent-activity gate from 60 to 15 minutes.
- Converted weather, traffic and festival stimulus engines to be location-aware: added per-location state caches and changed refresh/getters to accept a `location` parameter in `src/weather/weather-stimulus.ts`, `src/stimulus/traffic-stimulus.ts`, and `src/stimulus/festival-stimulus.ts`, and updated their messages/hashtags to avoid Bangalore-only wording.
- Generalized city context helpers by renaming/adding `getCityContext` (kept `getBangaloreContext` as an alias) and updated `src/utils/bangalore-context.ts` to produce location-aware strings; adjusted `src/personality.ts` to use the new API.
- Bumped persona config version and added `Constructive Contradiction Policy` to `config/SOUL.md`, and added a gap-analysis doc `docs/proactive-agent-gap-analysis.md` describing proactive shortfalls and priorities.

### Testing
- Ran unit tests with `vitest`, including the updated `utils/bangalore-context.test.ts` and the new `location-presence.test.ts`, and they passed.
- Exercised the Telegram location-share flow locally to ensure `setLiveUserLocation` is called and that proactive runner uses the resolved location for stimulus refresh (smoke check succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a518d8b4f48320aaa75f89f54f15ea)