### PR TITLE
Fix tool reflection timeout fallback and media context fallback usage

### DIFF
--- a/src/brain/tool-reflection.ts
+++ b/src/brain/tool-reflection.ts
@@ -32,7 +32,7 @@ interface ReflectionJSON {
 
 const REFLECTION_MODEL = 'llama-3.1-8b-instant'
 const MAX_RAW_CHARS = 3500
-const REFLECTION_TIMEOUT_MS = 3500
+const REFLECTION_TIMEOUT_MS = 6000
 
 let groq: Groq | null = null
 
@@ -158,7 +158,10 @@ Rules:
         return reflected
     } catch (err) {
         console.warn(`[brain/reflection] ${toolName}: reflection failed, using fallback directive`, (err as Error).message)
-        return null
+        return {
+            reflection: { summary: '', keyFacts: [] },
+            mediaDirective: fallbackDirective,
+        }
     }
 }
 

--- a/src/character/handler.ts
+++ b/src/character/handler.ts
@@ -1098,7 +1098,7 @@ export async function handleMessage(
       })
     }
 
-    const fallbackMediaFromContext = (!inlineMediaItem && !toolRawData && effectiveToolContext?.photoUrls?.length)
+    const fallbackMediaFromContext = (!inlineMediaItem && effectiveToolContext?.photoUrls?.length)
       ? [{
         type: 'photo' as const,
         url: effectiveToolContext.photoUrls[0],


### PR DESCRIPTION
### Motivation
- Tool reflection was timing out too quickly causing the reflection pass to return `null` and drop `mediaDirective`, which removed image captions and harmed persona consistency.
- The media extraction only handled food/grocery outputs, so when other tools (e.g. ride comparison) produced no extractable images the code skipped context photo fallbacks.
- Preserving grounded media directives during reflection failures and enabling context photo fallback improves image attachment and keeps Aria's persona consistent.

### Description
- Increased the reflection timeout from `3500`ms to `6000`ms in `src/brain/tool-reflection.ts` to give the 8B reflection model more time to produce JSON.
- Updated the reflection catch path in `src/brain/tool-reflection.ts` to return a fallback `ToolReflectionResult` (`{ reflection: { summary: '', keyFacts: [] }, mediaDirective: fallbackDirective }`) instead of `null`, preserving fallback media directives.
- Relaxed the handler fallback condition in `src/character/handler.ts` by removing the `!toolRawData` check so `effectiveToolContext.photoUrls` can be used as a fallback even when `toolRawData` exists but `extractMediaFromToolResult` returns no media.

### Testing
- Ran `npm run build` which executed the TypeScript compilation and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a52dfb3afc8320a9c5ed424671bc04)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added caption support to media objects for better metadata handling.

* **Bug Fixes**
  * Improved error handling for reflection requests, ensuring fallback data is returned instead of null.
  * Enhanced media fallback selection logic for more reliable photo URL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->