### PR TITLE
fix: restrict Routes traffic probe to Bengaluru and clean setup audit locals

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -677,7 +677,7 @@ tool_coverage_audit() {
     echo -e "  ${BOLD}🧭 Tool Coverage Audit (Env → Tool Readiness)${RESET}"
     echo ""
 
-    local places maps weather rapid traffic festival
+    local places maps weather rapid festival
     places=$(get_env_value "GOOGLE_PLACES_API_KEY")
     maps=$(get_env_value "GOOGLE_MAPS_API_KEY")
     weather=$(get_env_value "OPENWEATHERMAP_API_KEY")

--- a/src/stimulus/traffic-stimulus.ts
+++ b/src/stimulus/traffic-stimulus.ts
@@ -131,10 +131,11 @@ async function fetchRoutesApiTraffic(location: string): Promise<TrafficStimulusS
     const apiKey = process.env.GOOGLE_MAPS_API_KEY
     if (!apiKey) return null
 
+    // Current probe corridor is tuned for Bengaluru; use Distance Matrix fallback for other cities.
+    if (!isBengaluru(location)) return null
+
     // Use two well-known Bengaluru corridors as a probe route for meaningful traffic signal
-    const probeRoutes = isBengaluru(location)
-        ? { origin: '12.9352,77.6245', destination: '12.9698,77.7500' } // Silk Board → Whitefield
-        : { origin: location, destination: location }
+    const probeRoutes = { origin: '12.9352,77.6245', destination: '12.9698,77.7500' } // Silk Board → Whitefield
 
     try {
         const body = {


### PR DESCRIPTION
### Motivation
- Migrate traffic probing to the modern Google Routes API (with Distance Matrix fallback) and remove the misleading `TRAFFIC_API_KEY` env var so the code uses a single `GOOGLE_MAPS_API_KEY`. 
- Prevent the hardcoded Bengaluru probe corridor from being used for non-Bengaluru inputs, which produced misleading traffic signals for other cities. 
- Remove an unused local variable in the setup audit to reduce noise and potential shell warnings.

### Description
- Added Routes API probing (`fetchRoutesApiTraffic`) and a Distance Matrix fallback (`fetchDistanceMatrixTraffic`), consolidated to use `GOOGLE_MAPS_API_KEY` only, and removed references to `TRAFFIC_API_KEY` in `.env.example` and `setup.sh`.
- Introduced helper functions `buildApiState`, `parseDurationSeconds`, and `parseLatLng`, and updated `fetchGoogleTrafficCondition` to try Routes first, then Distance Matrix.
- Fixed the regression by short-circuiting `fetchRoutesApiTraffic` for non-Bengaluru inputs so the Distance Matrix fallback is used for other cities (early `return null`).
- Cleaned `tool_coverage_audit` in `setup.sh` by removing the unused `traffic` local variable and updated setup validation to prefer Routes API with Distance Matrix fallback.

### Testing
- Ran TypeScript compilation with `npx tsc --noEmit` and it completed successfully.
- Ran unit tests with `npx vitest run src/brain/router.test src/scout/scout.test` and all tests passed (`26 tests, 26 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5443ca8488320b1158ba0c6e1f5ff)