### PR TITLE
Fix place image grounding to avoid static map previews

### DIFF
--- a/src/character/handler.ts
+++ b/src/character/handler.ts
@@ -353,11 +353,12 @@ function extractMediaFromToolResult(rawData: unknown): MessageResponse['media'] 
   if (!rawData || typeof rawData !== 'object') return undefined
 
   const data = rawData as any
+  const isMapPreviewUrl = (url: string): boolean => /maps\.googleapis\.com\/maps\/api\/staticmap/i.test(url)
 
   // Grocery comparison: has a top-level images[] array with {url, caption}
   if (Array.isArray(data?.images)) {
     const media = data.images
-      .filter((img: any) => img?.url)
+      .filter((img: any) => typeof img?.url === 'string' && !isMapPreviewUrl(img.url))
       .slice(0, 6)
       .map((img: any) => ({
         type: 'photo' as const,
@@ -1184,7 +1185,8 @@ export async function handleMessage(
       }]
       : undefined
 
-    const venuePreviewMedia = !inlineMediaItem
+const venuePreviewMedia = !inlineMediaItem
+      && routeDecision.toolName !== 'search_places'
       ? buildVenuePreviewMedia(
         venues,
         typeof routeDecision.toolParams?.location === 'string' ? routeDecision.toolParams.location : user.homeLocation,

--- a/src/media/tool-media-context.test.ts
+++ b/src/media/tool-media-context.test.ts
@@ -18,6 +18,22 @@ describe('extractToolMediaContext', () => {
     expect(ctx?.searchQuery).toContain('Third Wave Coffee')
   })
 
+
+
+  it('prefers place image payloads and ignores static map previews', () => {
+    const ctx = extractToolMediaContext('search_places', {
+      raw: [{ displayName: { text: 'Araku Coffee' } }],
+      images: [
+        { url: 'https://maps.googleapis.com/maps/api/staticmap?center=12,77' },
+        { url: 'https://places.googleapis.com/v1/places/abc/media?key=test' },
+      ],
+    })
+
+    expect(ctx).not.toBeNull()
+    expect(ctx?.photoUrls).toContain('https://places.googleapis.com/v1/places/abc/media?key=test')
+    expect(ctx?.photoUrls.some(url => url.includes('staticmap'))).toBe(false)
+  })
+
   it('extracts dish-level images from food tool output', () => {
     const ctx = extractToolMediaContext('compare_food_prices', {
       raw: [

--- a/src/media/tool-media-context.ts
+++ b/src/media/tool-media-context.ts
@@ -22,14 +22,25 @@ function pushUnique(target: string[], value: unknown): void {
     if (!target.includes(trimmed)) target.push(trimmed)
 }
 
+function isMapPreviewUrl(url: string): boolean {
+    return /maps\.googleapis\.com\/maps\/api\/staticmap/i.test(url)
+}
+
+function pushPhotoUrl(target: string[], value: unknown): void {
+    if (typeof value !== 'string') return
+    const trimmed = value.trim()
+    if (!trimmed || isMapPreviewUrl(trimmed)) return
+    if (!target.includes(trimmed)) target.push(trimmed)
+}
+
 function extractFromPlace(entry: any, placeNames: string[], photoUrls: string[]): void {
     pushUnique(placeNames, entry?.displayName?.text)
     pushUnique(placeNames, entry?.name)
-    pushUnique(photoUrls, entry?.photoUrl)
-    pushUnique(photoUrls, entry?.imageUrl)
+    pushPhotoUrl(photoUrls, entry?.photoUrl)
+    pushPhotoUrl(photoUrls, entry?.imageUrl)
     if (Array.isArray(entry?.photos)) {
         for (const p of entry.photos) {
-            pushUnique(photoUrls, p?.url)
+            pushPhotoUrl(photoUrls, p?.url)
         }
     }
 }
@@ -38,14 +49,14 @@ function extractFromFoodEntry(entry: any, placeNames: string[], itemNames: strin
     pushUnique(placeNames, entry?.restaurantName)
     pushUnique(placeNames, entry?.restaurant)
     pushUnique(placeNames, entry?.name)
-    pushUnique(photoUrls, entry?.restaurantImageUrl)
-    pushUnique(photoUrls, entry?.imageUrl)
+    pushPhotoUrl(photoUrls, entry?.restaurantImageUrl)
+    pushPhotoUrl(photoUrls, entry?.imageUrl)
 
     if (Array.isArray(entry?.items)) {
         for (const item of entry.items) {
             pushUnique(itemNames, item?.name)
-            pushUnique(photoUrls, item?.imageUrl)
-            pushUnique(photoUrls, item?.image)
+            pushPhotoUrl(photoUrls, item?.imageUrl)
+            pushPhotoUrl(photoUrls, item?.image)
         }
     }
 }
@@ -76,6 +87,11 @@ export function extractToolMediaContext(toolName: string, rawData: unknown): Too
             : null
 
     if (toolName === 'search_places' && Array.isArray(rootArray)) {
+        if (Array.isArray(data?.images)) {
+            for (const img of data.images.slice(0, 8)) {
+                pushPhotoUrl(photoUrls, img?.url)
+            }
+        }
         for (const place of rootArray.slice(0, 8)) {
             extractFromPlace(place, placeNames, photoUrls)
         }
@@ -102,8 +118,8 @@ export function extractToolMediaContext(toolName: string, rawData: unknown): Too
         if (Array.isArray(rootArray)) {
             for (const entry of rootArray.slice(0, 8)) {
                 pushUnique(itemNames, entry?.name)
-                pushUnique(photoUrls, entry?.imageUrl)
-                pushUnique(photoUrls, entry?.image)
+                pushPhotoUrl(photoUrls, entry?.imageUrl)
+                pushPhotoUrl(photoUrls, entry?.image)
             }
         }
     } else if (Array.isArray(rootArray)) {
@@ -128,4 +144,3 @@ export function extractToolMediaContext(toolName: string, rawData: unknown): Too
         photoUrls,
     }
 }
-


### PR DESCRIPTION
### Motivation
- Place search results were sometimes surfaced as Google Static Map snapshots instead of real place photos because map preview URLs were present in tool payloads and could leak into media selection or fallback to venue preview images.
- The pipeline needed a simple guard to prefer actual image assets and avoid treating `staticmap` URLs as place photos.

### Description
- Added `isMapPreviewUrl` and `pushPhotoUrl` helpers and switched photo collection to use `pushPhotoUrl` so map preview URLs are filtered out when assembling `photoUrls` in `src/media/tool-media-context.ts`.
- Read and include `data.images[]` for `search_places` payloads while filtering out static map links so place image payloads are preferred for `search_places` results.
- Updated `extractMediaFromToolResult` in `src/character/handler.ts` to ignore Google Static Map URLs when building Telegram photo attachments.
- Prevented the static map `venuePreviewMedia` fallback from being used for `search_places` responses so place-search results won’t be replaced by map snapshots.
- Added a regression test in `src/media/tool-media-context.test.ts` ensuring static map URLs are excluded but valid place image URLs are preserved.

### Testing
- Ran `npm test -- src/media/tool-media-context.test.ts`, which passed (3 tests, all green).
- Ran `npm run build` (`tsc`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a55a438c948320af5b33a30b97c279)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed Google Maps static preview images appearing unintentionally in media results.
* Prevented venue previews from displaying during place-search operations.
* Improved image selection to prioritize actual service provider images over map previews across search and delivery services.

## Tests
* Added test coverage for image handling in place search results, ensuring proper prioritization of source images over static maps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->