### PR TITLE
Fix Places photo host detection to avoid Telegram map-thumbnail fallback

### DIFF
--- a/src/channels.ts
+++ b/src/channels.ts
@@ -31,8 +31,33 @@ export interface ChannelAdapter {
 
 /** Detect if a URL is a resolved Google Places photo (lh3 CDN or places API) */
 function isLikelyPlacesPhotoUrl(url: string): boolean {
-  return /lh3\.googleusercontent\.com/i.test(url)
-    || /places\.googleapis\.com\/v1\/.+\/media/i.test(url)
+  try {
+    const parsed = new URL(url)
+    const host = parsed.hostname.toLowerCase()
+    const path = parsed.pathname.toLowerCase()
+
+    if (host.includes('places.googleapis.com') && path.includes('/media')) {
+      return true
+    }
+
+    if (
+      host.endsWith('googleusercontent.com')
+      || host.endsWith('ggpht.com')
+    ) {
+      // Places photo URLs commonly use one of these path patterns.
+      if (
+        path.includes('/place-photos/')
+        || path.includes('/gpms-cs-s/')
+        || path.includes('/p/')
+      ) {
+        return true
+      }
+    }
+
+    return false
+  } catch {
+    return false
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- broaden `isLikelyPlacesPhotoUrl()` in `src/channels.ts` to detect modern Google Places photo URL variants
- support `googleusercontent.com` and `ggpht.com` hosts with common Places paths (`/place-photos/`, `/gpms-cs-s/`, `/p/`)
- keep `places.googleapis.com/.../media` detection and safe URL parsing

## Why
Some valid Places photos were not detected as Places media, so the send path could fall back to URL-based Telegram sends, which may render map-style thumbnails instead of real venue photos.

## Validation
- `npm run build` passed
- Node 20 full tests were executed; there is one unrelated existing failure in `src/media/tool-media-context.test.ts` on current `origin/main` (not touched by this PR).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal URL detection logic with enhanced reliability and error handling. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->