### PR TITLE
feat(phase-0): DB migrations for fusion architecture tables

### DIFF
--- a/database/migrations/005-fusion-architecture-tables.sql
+++ b/database/migrations/005-fusion-architecture-tables.sql
@@ -1,0 +1,171 @@
+-- Migration 005: Fusion Architecture Tables — Issue #127
+-- Creates the 6 tables required by Phase 0 of the fusion architecture migration.
+-- All other phases (1-7) depend on these tables existing first.
+-- Branch: phase-0/db-migrations-127
+
+-- ============================================================
+-- 1. proactive_state
+-- Sentinel writes scored stimulus context; Alpha reads on each
+-- message to inject relevant proactive context into the response.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS proactive_state (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id      UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    stimulus_type TEXT NOT NULL,
+        -- 'weather' | 'traffic' | 'event' | 'social' | 'food' | 'price'
+    stimulus_key TEXT NOT NULL,
+        -- stable identifier e.g. 'rain_commute_2026-03-21_morning'
+    score        FLOAT NOT NULL CHECK (score >= 0 AND score <= 1),
+        -- Fusion score that caused this write (0.0–1.0)
+    data         JSONB NOT NULL DEFAULT '{}',
+        -- raw stimulus payload (weather JSON, event details, etc.)
+    result_ref   UUID,
+        -- FK to tool_results.id if Sentinel pre-fetched a tool result
+    status       TEXT NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active', 'stale', 'delivered', 'dismissed', 'expired')),
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at   TIMESTAMPTZ,
+        -- NULL = no expiry; Sentinel cleanup deletes expired rows
+
+    CONSTRAINT uq_proactive_state_user_stimulus UNIQUE (user_id, stimulus_key)
+);
+
+-- Primary read path: Alpha fetches active rows for a user on every message
+CREATE INDEX IF NOT EXISTS idx_proactive_state_user_status
+    ON proactive_state(user_id, status);
+
+-- Cleanup job index: find expired active rows efficiently
+CREATE INDEX IF NOT EXISTS idx_proactive_state_expires_active
+    ON proactive_state(expires_at)
+    WHERE status = 'active';
+
+
+-- ============================================================
+-- 2. stimulus_cache
+-- Caches raw data from external APIs (weather, traffic, events)
+-- to avoid redundant outbound calls across multiple users.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS stimulus_cache (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    source      TEXT NOT NULL,
+        -- 'openweather' | 'traffic_api' | 'events_api' | 'mess_menu' | 'price_tracker'
+    cache_key   TEXT NOT NULL,
+        -- composite key e.g. 'openweather::bangalore' or 'events::indiranagar::2026-03-21'
+    data_json   JSONB NOT NULL,
+    fetched_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    ttl_seconds INT NOT NULL DEFAULT 1800,
+        -- default 30 min; callers may override per source
+
+    CONSTRAINT uq_stimulus_cache_source_key UNIQUE (source, cache_key)
+);
+
+-- Freshness check: Sentinel uses fetched_at + ttl_seconds to decide if stale
+CREATE INDEX IF NOT EXISTS idx_stimulus_cache_lookup
+    ON stimulus_cache(source, cache_key, fetched_at);
+
+
+-- ============================================================
+-- 3. tool_results
+-- Pre-fetched tool call results written by Sentinel so Alpha
+-- can serve answers instantly without an outbound API call.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS tool_results (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id     UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    tool_name   TEXT NOT NULL,
+        -- 'cab_compare' | 'weather_check' | 'place_search' | etc.
+    args_hash   TEXT NOT NULL,
+        -- SHA-256 of JSON.stringify(sorted args) for dedup
+    result      JSONB NOT NULL,
+    cached_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at  TIMESTAMPTZ,
+    used        BOOLEAN NOT NULL DEFAULT FALSE,
+        -- Alpha sets TRUE after consuming; cleanup deletes used rows
+
+    CONSTRAINT uq_tool_results_user_tool_args UNIQUE (user_id, tool_name, args_hash)
+);
+
+-- Alpha lookup: find unused pre-fetched result for a user + tool
+CREATE INDEX IF NOT EXISTS idx_tool_results_lookup
+    ON tool_results(user_id, tool_name, used)
+    WHERE NOT used;
+
+
+-- ============================================================
+-- 4. pulse_history
+-- Append-only audit trail of every Pulse score change.
+-- Used by analytics, Sentinel recalibration, and debugging.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS pulse_history (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id        UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    score          INT NOT NULL CHECK (score >= 0 AND score <= 100),
+    state          TEXT NOT NULL
+        CHECK (state IN ('PASSIVE', 'CURIOUS', 'ENGAGED', 'PROACTIVE')),
+    previous_state TEXT
+        CHECK (previous_state IN ('PASSIVE', 'CURIOUS', 'ENGAGED', 'PROACTIVE')),
+    delta          INT NOT NULL,
+        -- signed change: +14 committed, -18 rejection, +8 soft-yes, -5 ignore
+    signal_source  TEXT NOT NULL,
+        -- 'user_message' | 'proactive_rejection' | 'tool_action' | 'proactive_accepted'
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Recent history per user (most recent first)
+CREATE INDEX IF NOT EXISTS idx_pulse_history_user_time
+    ON pulse_history(user_id, created_at DESC);
+
+
+-- ============================================================
+-- 5. signal_packets
+-- Alpha writes one packet per reactive response. Sentinel reads
+-- these on its next loop to recalibrate proactive scoring.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS signal_packets (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id             UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    invalidated_stimuli TEXT[],
+        -- array of stimulus_key values Alpha found stale/irrelevant
+    current_direction   TEXT,
+        -- topic/intent Alpha detected in this message e.g. 'weekend_travel'
+    extracted_intents   TEXT[],
+        -- new intents to feed into Sentinel's next scoring pass
+    engagement_signal   TEXT
+        CHECK (engagement_signal IN ('positive', 'negative', 'neutral')),
+    processed           BOOLEAN NOT NULL DEFAULT FALSE,
+        -- Sentinel sets TRUE after reading; cleanup deletes old processed rows
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Sentinel pickup: fetch unprocessed packets per user
+CREATE INDEX IF NOT EXISTS idx_signal_packets_unprocessed
+    ON signal_packets(user_id, processed)
+    WHERE NOT processed;
+
+
+-- ============================================================
+-- 6. pushback_tracker
+-- Tracks per-user per-stimulus-type rejection counts so Sentinel
+-- can apply the pushback protocol (retry once with different angle,
+-- then back off to REACTIVE mode on second rejection).
+-- ============================================================
+CREATE TABLE IF NOT EXISTS pushback_tracker (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id          UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    stimulus_type    TEXT NOT NULL,
+    rejection_count  INT NOT NULL DEFAULT 0 CHECK (rejection_count >= 0),
+    retry_angle_used TEXT,
+        -- records which retry angle was attempted so Sentinel doesn't repeat it
+    last_rejected_at TIMESTAMPTZ,
+
+    CONSTRAINT uq_pushback_tracker_user_type UNIQUE (user_id, stimulus_type)
+);
+
+
+-- ============================================================
+-- Cleanup queries (run by Sentinel loop — do not run manually)
+-- ============================================================
+-- DELETE FROM proactive_state WHERE expires_at < NOW() OR status IN ('stale', 'expired');
+-- DELETE FROM tool_results WHERE expires_at < NOW() OR used = TRUE;
+-- DELETE FROM signal_packets WHERE processed = TRUE AND created_at < NOW() - INTERVAL '1 hour';
+-- DELETE FROM stimulus_cache WHERE fetched_at + (ttl_seconds * INTERVAL '1 second') < NOW();

--- a/src/db/fusion-tables.ts
+++ b/src/db/fusion-tables.ts
@@ -1,0 +1,355 @@
+/**
+ * Fusion Architecture — DB Types & Query Helpers
+ * Issue #127 / Phase 0
+ *
+ * Covers the 6 tables created in migration 005:
+ *   proactive_state, stimulus_cache, tool_results,
+ *   pulse_history, signal_packets, pushback_tracker
+ */
+
+import { Pool } from 'pg'
+
+// ─────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────
+
+export type ProactiveStatus = 'active' | 'stale' | 'delivered' | 'dismissed' | 'expired'
+export type PulseState = 'PASSIVE' | 'CURIOUS' | 'ENGAGED' | 'PROACTIVE'
+export type EngagementSignal = 'positive' | 'negative' | 'neutral'
+
+export interface ProactiveStateRow {
+    id: string
+    user_id: string
+    stimulus_type: string
+    stimulus_key: string
+    score: number
+    data: Record<string, unknown>
+    result_ref: string | null
+    status: ProactiveStatus
+    created_at: Date
+    expires_at: Date | null
+}
+
+export interface StimulusCacheRow {
+    id: string
+    source: string
+    cache_key: string
+    data_json: Record<string, unknown>
+    fetched_at: Date
+    ttl_seconds: number
+}
+
+export interface ToolResultRow {
+    id: string
+    user_id: string
+    tool_name: string
+    args_hash: string
+    result: Record<string, unknown>
+    cached_at: Date
+    expires_at: Date | null
+    used: boolean
+}
+
+export interface PulseHistoryRow {
+    id: string
+    user_id: string
+    score: number
+    state: PulseState
+    previous_state: PulseState | null
+    delta: number
+    signal_source: string
+    created_at: Date
+}
+
+export interface SignalPacketRow {
+    id: string
+    user_id: string
+    invalidated_stimuli: string[] | null
+    current_direction: string | null
+    extracted_intents: string[] | null
+    engagement_signal: EngagementSignal | null
+    processed: boolean
+    created_at: Date
+}
+
+export interface PushbackTrackerRow {
+    id: string
+    user_id: string
+    stimulus_type: string
+    rejection_count: number
+    retry_angle_used: string | null
+    last_rejected_at: Date | null
+}
+
+// ─────────────────────────────────────────────
+// proactive_state
+// ─────────────────────────────────────────────
+
+export async function getActiveProactiveState(
+    pool: Pool,
+    userId: string
+): Promise<ProactiveStateRow[]> {
+    const { rows } = await pool.query<ProactiveStateRow>(
+        `SELECT * FROM proactive_state
+         WHERE user_id = $1 AND status = 'active'
+           AND (expires_at IS NULL OR expires_at > NOW())
+         ORDER BY score DESC`,
+        [userId]
+    )
+    return rows
+}
+
+export async function upsertProactiveState(
+    pool: Pool,
+    data: Pick<ProactiveStateRow, 'user_id' | 'stimulus_type' | 'stimulus_key' | 'score' | 'data' | 'result_ref' | 'expires_at'>
+): Promise<ProactiveStateRow> {
+    const { rows } = await pool.query<ProactiveStateRow>(
+        `INSERT INTO proactive_state
+           (user_id, stimulus_type, stimulus_key, score, data, result_ref, expires_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         ON CONFLICT (user_id, stimulus_key)
+         DO UPDATE SET
+           score       = EXCLUDED.score,
+           data        = EXCLUDED.data,
+           result_ref  = EXCLUDED.result_ref,
+           status      = 'active',
+           expires_at  = EXCLUDED.expires_at
+         RETURNING *`,
+        [data.user_id, data.stimulus_type, data.stimulus_key, data.score, data.data, data.result_ref, data.expires_at]
+    )
+    return rows[0]
+}
+
+export async function updateProactiveStatus(
+    pool: Pool,
+    userId: string,
+    stimulusKey: string,
+    status: ProactiveStatus
+): Promise<void> {
+    await pool.query(
+        `UPDATE proactive_state SET status = $3
+         WHERE user_id = $1 AND stimulus_key = $2`,
+        [userId, stimulusKey, status]
+    )
+}
+
+export async function invalidateProactiveStimuli(
+    pool: Pool,
+    userId: string,
+    stimulusKeys: string[]
+): Promise<void> {
+    if (stimulusKeys.length === 0) return
+    await pool.query(
+        `UPDATE proactive_state SET status = 'stale'
+         WHERE user_id = $1 AND stimulus_key = ANY($2)`,
+        [userId, stimulusKeys]
+    )
+}
+
+// ─────────────────────────────────────────────
+// stimulus_cache
+// ─────────────────────────────────────────────
+
+export async function getStimulusCache(
+    pool: Pool,
+    source: string,
+    cacheKey: string
+): Promise<StimulusCacheRow | null> {
+    const { rows } = await pool.query<StimulusCacheRow>(
+        `SELECT * FROM stimulus_cache
+         WHERE source = $1 AND cache_key = $2
+           AND fetched_at + (ttl_seconds * INTERVAL '1 second') > NOW()`,
+        [source, cacheKey]
+    )
+    return rows[0] ?? null
+}
+
+export async function upsertStimulusCache(
+    pool: Pool,
+    data: Pick<StimulusCacheRow, 'source' | 'cache_key' | 'data_json' | 'ttl_seconds'>
+): Promise<void> {
+    await pool.query(
+        `INSERT INTO stimulus_cache (source, cache_key, data_json, ttl_seconds)
+         VALUES ($1, $2, $3, $4)
+         ON CONFLICT (source, cache_key)
+         DO UPDATE SET data_json = EXCLUDED.data_json, fetched_at = NOW(), ttl_seconds = EXCLUDED.ttl_seconds`,
+        [data.source, data.cache_key, data.data_json, data.ttl_seconds]
+    )
+}
+
+// ─────────────────────────────────────────────
+// tool_results
+// ─────────────────────────────────────────────
+
+export async function getToolResult(
+    pool: Pool,
+    userId: string,
+    toolName: string,
+    argsHash: string
+): Promise<ToolResultRow | null> {
+    const { rows } = await pool.query<ToolResultRow>(
+        `SELECT * FROM tool_results
+         WHERE user_id = $1 AND tool_name = $2 AND args_hash = $3
+           AND NOT used
+           AND (expires_at IS NULL OR expires_at > NOW())`,
+        [userId, toolName, argsHash]
+    )
+    return rows[0] ?? null
+}
+
+export async function insertToolResult(
+    pool: Pool,
+    data: Pick<ToolResultRow, 'user_id' | 'tool_name' | 'args_hash' | 'result' | 'expires_at'>
+): Promise<string> {
+    const { rows } = await pool.query<{ id: string }>(
+        `INSERT INTO tool_results (user_id, tool_name, args_hash, result, expires_at)
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT (user_id, tool_name, args_hash)
+         DO UPDATE SET result = EXCLUDED.result, cached_at = NOW(), expires_at = EXCLUDED.expires_at, used = FALSE
+         RETURNING id`,
+        [data.user_id, data.tool_name, data.args_hash, data.result, data.expires_at]
+    )
+    return rows[0].id
+}
+
+export async function markToolResultUsed(pool: Pool, id: string): Promise<void> {
+    await pool.query(`UPDATE tool_results SET used = TRUE WHERE id = $1`, [id])
+}
+
+// ─────────────────────────────────────────────
+// pulse_history
+// ─────────────────────────────────────────────
+
+export async function insertPulseHistory(
+    pool: Pool,
+    data: Pick<PulseHistoryRow, 'user_id' | 'score' | 'state' | 'previous_state' | 'delta' | 'signal_source'>
+): Promise<void> {
+    await pool.query(
+        `INSERT INTO pulse_history (user_id, score, state, previous_state, delta, signal_source)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [data.user_id, data.score, data.state, data.previous_state, data.delta, data.signal_source]
+    )
+}
+
+export async function getRecentPulseHistory(
+    pool: Pool,
+    userId: string,
+    limit = 10
+): Promise<PulseHistoryRow[]> {
+    const { rows } = await pool.query<PulseHistoryRow>(
+        `SELECT * FROM pulse_history
+         WHERE user_id = $1
+         ORDER BY created_at DESC
+         LIMIT $2`,
+        [userId, limit]
+    )
+    return rows
+}
+
+// ─────────────────────────────────────────────
+// signal_packets
+// ─────────────────────────────────────────────
+
+export async function insertSignalPacket(
+    pool: Pool,
+    data: Pick<SignalPacketRow, 'user_id' | 'invalidated_stimuli' | 'current_direction' | 'extracted_intents' | 'engagement_signal'>
+): Promise<void> {
+    await pool.query(
+        `INSERT INTO signal_packets
+           (user_id, invalidated_stimuli, current_direction, extracted_intents, engagement_signal)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [data.user_id, data.invalidated_stimuli, data.current_direction, data.extracted_intents, data.engagement_signal]
+    )
+}
+
+export async function getUnprocessedSignalPackets(
+    pool: Pool,
+    userId: string
+): Promise<SignalPacketRow[]> {
+    const { rows } = await pool.query<SignalPacketRow>(
+        `SELECT * FROM signal_packets
+         WHERE user_id = $1 AND NOT processed
+         ORDER BY created_at ASC`,
+        [userId]
+    )
+    return rows
+}
+
+export async function markSignalPacketsProcessed(
+    pool: Pool,
+    ids: string[]
+): Promise<void> {
+    if (ids.length === 0) return
+    await pool.query(
+        `UPDATE signal_packets SET processed = TRUE WHERE id = ANY($1)`,
+        [ids]
+    )
+}
+
+// ─────────────────────────────────────────────
+// pushback_tracker
+// ─────────────────────────────────────────────
+
+export async function getPushbackCount(
+    pool: Pool,
+    userId: string,
+    stimulusType: string
+): Promise<PushbackTrackerRow | null> {
+    const { rows } = await pool.query<PushbackTrackerRow>(
+        `SELECT * FROM pushback_tracker WHERE user_id = $1 AND stimulus_type = $2`,
+        [userId, stimulusType]
+    )
+    return rows[0] ?? null
+}
+
+export async function incrementPushback(
+    pool: Pool,
+    userId: string,
+    stimulusType: string,
+    retryAngleUsed?: string
+): Promise<number> {
+    const { rows } = await pool.query<{ rejection_count: number }>(
+        `INSERT INTO pushback_tracker (user_id, stimulus_type, rejection_count, retry_angle_used, last_rejected_at)
+         VALUES ($1, $2, 1, $3, NOW())
+         ON CONFLICT (user_id, stimulus_type)
+         DO UPDATE SET
+           rejection_count  = pushback_tracker.rejection_count + 1,
+           retry_angle_used = COALESCE($3, pushback_tracker.retry_angle_used),
+           last_rejected_at = NOW()
+         RETURNING rejection_count`,
+        [userId, stimulusType, retryAngleUsed ?? null]
+    )
+    return rows[0].rejection_count
+}
+
+export async function resetPushback(
+    pool: Pool,
+    userId: string,
+    stimulusType: string
+): Promise<void> {
+    await pool.query(
+        `UPDATE pushback_tracker SET rejection_count = 0, retry_angle_used = NULL
+         WHERE user_id = $1 AND stimulus_type = $2`,
+        [userId, stimulusType]
+    )
+}
+
+// ─────────────────────────────────────────────
+// Cleanup (called by Sentinel loop)
+// ─────────────────────────────────────────────
+
+export async function runFusionTableCleanup(pool: Pool): Promise<void> {
+    await pool.query(`
+        DELETE FROM proactive_state
+        WHERE expires_at < NOW() OR status IN ('stale', 'expired');
+
+        DELETE FROM tool_results
+        WHERE expires_at < NOW() OR used = TRUE;
+
+        DELETE FROM signal_packets
+        WHERE processed = TRUE AND created_at < NOW() - INTERVAL '1 hour';
+
+        DELETE FROM stimulus_cache
+        WHERE fetched_at + (ttl_seconds * INTERVAL '1 second') < NOW();
+    `)
+}


### PR DESCRIPTION
## Phase 0 — Issue #127

Creates the 6 database tables required by the fusion architecture migration. All subsequent phases (1–7) depend on these tables existing first. Full plan: [`docs/IMPLEMENTATION_PLAN.md`](../blob/dev/fusion-architecture-v2/docs/IMPLEMENTATION_PLAN.md)

## Tables

| Table | Writer | Reader |
|---|---|---|
| `proactive_state` | Sentinel | Alpha (every message) |
| `stimulus_cache` | Sentinel / API fetchers | Sentinel scoring loop |
| `tool_results` | Sentinel pre-fetch | Alpha (zero-latency tool responses) |
| `pulse_history` | Alpha fire-and-forget | Analytics / Sentinel recalibration |
| `signal_packets` | Alpha fire-and-forget | Sentinel next loop |
| `pushback_tracker` | Pulse FSM | Sentinel pushback protocol |

## Files

- `database/migrations/005-fusion-architecture-tables.sql`
- `src/db/fusion-tables.ts`

## Phase 0 Checklist

- [ ] All 6 tables created with correct schemas and indexes
- [ ] `INSERT INTO proactive_state` + `SELECT` round-trip works
- [ ] Existing bot still responds to "hello" (regression check)
- [ ] Telegram message → webhook → user record in DB → message in sessions table

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)