### PR TITLE
feat(phase-2): tool definitions + alpha provider migration (#129, #140)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,6 +91,11 @@ EMBEDDING_DIMS=768
 PORT=3000
 NODE_ENV=production
 
+# Logging — used in: src/logger.ts
+# Options: trace | debug | info | warn | error | fatal
+# Defaults to 'debug' in development, 'info' in production
+LOG_LEVEL=info
+
 # ===========================================
 # DEV 4: Travel Tools
 # ===========================================
@@ -134,6 +139,54 @@ ZOMATO_MCP_TOKEN=
 ZOMATO_MCP_REFRESH_TOKEN=
 
 # ===========================================
+# Phase 2 — Alpha LLM Providers (Issue #129)
+# ===========================================
+
+# Together AI — primary Alpha provider for reactive pipeline
+# Used in: src/llm/providers/together.ts
+# Get key: https://api.together.xyz/settings/api-keys
+TOGETHER_API_KEY=
+# Used in: src/llm/providers/together.ts
+TOGETHER_CHAT_MODEL=meta-llama/Llama-3.3-70B-Instruct-Turbo
+
+# Fireworks AI — third-tier fallback provider (after Bedrock + Together)
+# Used in: src/llm/providers/fireworks.ts
+# Get key: https://fireworks.ai/account/api-keys
+FIREWORKS_API_KEY=
+# Used in: src/llm/providers/fireworks.ts
+FIREWORKS_MODEL=accounts/fireworks/models/llama-v3p1-70b-instruct
+
+# Alpha provider benchmark script — controls which providers to test and how many rounds
+# Used in: src/providers/alpha-benchmark.ts
+BENCHMARK_PROVIDERS=together,fireworks,groq
+BENCHMARK_ROUNDS=3
+
+# ===========================================
+# Redis — Caching Layer
+# ===========================================
+
+# Used in: src/archivist/redis-client.ts (session archival retrieval)
+#          src/scout/cache.ts (tool result caching)
+# Required for archivist and scout cache. No in-process fallback exists.
+REDIS_URL=redis://localhost:6379
+
+# ===========================================
+# Tunable Timeouts & Behaviour
+# ===========================================
+
+# Minutes of inactivity before proactive intent orchestrator fires
+# Used in: src/proactive-intent/orchestrator.ts (default: 15)
+PROACTIVE_INTENT_IDLE_MINUTES=15
+
+# Minutes of inactivity before task orchestrator marks a workflow stalled
+# Used in: src/task-orchestrator/orchestrator.ts (default: 20)
+TASK_ORCHESTRATOR_IDLE_MINUTES=20
+
+# Minutes of inactivity before archivist summarises the session
+# Used in: src/archivist/session-summaries.ts (default: 30)
+SESSION_SUMMARY_INACTIVITY_MIN=30
+
+# ===========================================
 # Proactive Agent — Stimulus APIs (Issues #90, #91)
 # ===========================================
 
@@ -150,9 +203,17 @@ FESTIVAL_API_KEY=
 # ===========================================
 
 # AWS credentials (shared across all subagents)
+# Used in: src/aws/aws-config.ts
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
+# Optional — short-lived STS credentials. Used in: src/aws/aws-config.ts
+AWS_SESSION_TOKEN=
+# Primary region for all AWS SDK clients. Used in: src/aws/aws-config.ts, src/archivist/s3-archive.ts
+# AWS_REGION is the generic SDK default; AWS_BEDROCK_REGION can override for Bedrock specifically
+AWS_REGION=ap-south-1
 AWS_BEDROCK_REGION=ap-south-1
+# Set to 'true' to enable AWS client initialisation. Used in: src/aws/aws-clients.test.ts (test flag)
+AWS_ENABLED=false
 
 # DynamoDB (Pulse subagent — hot-path engagement scores)
 AWS_DYNAMODB_TABLE_USER_STATE=aria-user-state

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ desktop.ini
 # ─── Playwright ──────────────────────────────────────────────────────────────
 playwright-report/
 test-results/
+
+IMPLEMENTATION_PLAN.md

--- a/src/archivist/memory-queue.ts
+++ b/src/archivist/memory-queue.ts
@@ -17,6 +17,9 @@ import { addMemories } from '../memory-store.js'
 import { addToGraph } from '../graph-memory.js'
 import { processUserMessage } from '../memory.js'
 import { updateConversationGoal } from '../cognitive.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'memory-queue' })
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -66,7 +69,7 @@ export async function enqueueMemoryWrite(
         )
     } catch (err) {
         // Log but never throw — a queue insertion failure must not break the response path
-        console.error('[archivist/queue] Failed to enqueue memory write:', (err as Error).message)
+        log.error({ err }, 'Failed to enqueue memory write')
     }
 }
 
@@ -137,14 +140,14 @@ export async function processMemoryWriteQueue(batchSize = 20): Promise<number> {
                 )
 
                 if (failed) {
-                    console.error(
-                        `[archivist/queue] Item ${item.queueId} exhausted retries (${item.operationType}):`,
-                        msg
+                    log.error(
+                        { err, queueId: item.queueId, operationType: item.operationType },
+                        `Item exhausted retries`,
                     )
                 } else {
-                    console.warn(
-                        `[archivist/queue] Item ${item.queueId} attempt ${item.attempts}/${item.maxAttempts} failed — will retry:`,
-                        msg
+                    log.warn(
+                        { queueId: item.queueId, attempt: item.attempts, maxAttempts: item.maxAttempts },
+                        'Item attempt failed — will retry',
                     )
                 }
             }
@@ -159,8 +162,9 @@ export async function processMemoryWriteQueue(batchSize = 20): Promise<number> {
     )
 
     if (successCount > 0 || claimed.rows.length > 0) {
-        console.log(
-            `[archivist/queue] Processed ${successCount}/${claimed.rows.length} items`
+        log.info(
+            { successCount, total: claimed.rows.length },
+            'Processed queue items',
         )
     }
 

--- a/src/archivist/redis-cache.ts
+++ b/src/archivist/redis-cache.ts
@@ -11,6 +11,9 @@
  */
 
 import { getRedis } from './redis-client.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'redis-cache' })
 
 // ─── Key Factories ───────────────────────────────────────────────────────────
 
@@ -32,7 +35,7 @@ export async function cacheEmbedding(text: string, vector: number[]): Promise<vo
     try {
         await redis.setex(KEY_EMBEDDING(text), DEFAULT_TTL_S, JSON.stringify(vector))
     } catch (err) {
-        console.error('[archivist/cache] cacheEmbedding error:', (err as Error).message)
+        log.error({ err }, 'cacheEmbedding error')
     }
 }
 
@@ -47,7 +50,7 @@ export async function getCachedEmbedding(text: string): Promise<number[] | null>
         if (!raw) return null
         return JSON.parse(raw) as number[]
     } catch (err) {
-        console.error('[archivist/cache] getCachedEmbedding error:', (err as Error).message)
+        log.error({ err }, 'getCachedEmbedding error')
         return null
     }
 }
@@ -70,7 +73,7 @@ export async function cacheSession(userId: string, session: CachedSession): Prom
     try {
         await redis.setex(KEY_SESSION(userId), DEFAULT_TTL_S, JSON.stringify(session))
     } catch (err) {
-        console.error('[archivist/cache] cacheSession error:', (err as Error).message)
+        log.error({ err }, 'cacheSession error')
     }
 }
 
@@ -85,7 +88,7 @@ export async function getCachedSession(userId: string): Promise<CachedSession | 
         if (!raw) return null
         return JSON.parse(raw) as CachedSession
     } catch (err) {
-        console.error('[archivist/cache] getCachedSession error:', (err as Error).message)
+        log.error({ err }, 'getCachedSession error')
         return null
     }
 }
@@ -99,7 +102,7 @@ export async function invalidateSession(userId: string): Promise<void> {
     try {
         await redis.del(KEY_SESSION(userId))
     } catch (err) {
-        console.error('[archivist/cache] invalidateSession error:', (err as Error).message)
+        log.error({ err }, 'invalidateSession error')
     }
 }
 
@@ -116,7 +119,7 @@ export async function cachePreferences(userId: string, prefs: PreferencesMap): P
     try {
         await redis.setex(KEY_PREFERENCES(userId), DEFAULT_TTL_S, JSON.stringify(prefs))
     } catch (err) {
-        console.error('[archivist/cache] cachePreferences error:', (err as Error).message)
+        log.error({ err }, 'cachePreferences error')
     }
 }
 
@@ -131,7 +134,7 @@ export async function getCachedPreferences(userId: string): Promise<PreferencesM
         if (!raw) return null
         return JSON.parse(raw) as PreferencesMap
     } catch (err) {
-        console.error('[archivist/cache] getCachedPreferences error:', (err as Error).message)
+        log.error({ err }, 'getCachedPreferences error')
         return null
     }
 }
@@ -145,6 +148,6 @@ export async function invalidatePreferences(userId: string): Promise<void> {
     try {
         await redis.del(KEY_PREFERENCES(userId))
     } catch (err) {
-        console.error('[archivist/cache] invalidatePreferences error:', (err as Error).message)
+        log.error({ err }, 'invalidatePreferences error')
     }
 }

--- a/src/archivist/redis-client.ts
+++ b/src/archivist/redis-client.ts
@@ -9,6 +9,9 @@
  */
 
 import { Redis } from 'ioredis'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'redis-client' })
 
 let redisClient: Redis | null = null
 let initialized = false
@@ -22,7 +25,7 @@ export function initRedis(): void {
 
     const redisUrl = process.env.REDIS_URL
     if (!redisUrl) {
-        console.log('[archivist/redis] REDIS_URL not set — Redis caching disabled')
+        log.info('REDIS_URL not set — Redis caching disabled')
         initialized = true // deliberate skip — no retry needed
         return
     }
@@ -36,22 +39,22 @@ export function initRedis(): void {
 
         client.on('error', (err: Error) => {
             // Log but don't crash — Redis is optional
-            console.error('[archivist/redis] Connection error:', err.message)
+            log.error({ err }, 'Connection error')
         })
         client.on('connect', () => {
-            console.log('[archivist/redis] Connected to Redis')
+            log.info('Connected to Redis')
         })
         client.on('reconnecting', () => {
-            console.warn('[archivist/redis] Reconnecting to Redis...')
+            log.warn('Reconnecting to Redis...')
         })
         client.on('close', () => {
-            console.warn('[archivist/redis] Connection closed')
+            log.warn('Connection closed')
         })
 
         redisClient = client
         initialized = true // only mark initialized after successful creation
     } catch (err) {
-        console.error('[archivist/redis] Failed to initialize Redis:', err)
+        log.error({ err }, 'Failed to initialize Redis')
         redisClient = null
         // DO NOT set initialized = true here — allows retry on next call
     }

--- a/src/archivist/retrieval.ts
+++ b/src/archivist/retrieval.ts
@@ -21,6 +21,9 @@
 import { embed } from '../embeddings.js'
 import { getPool } from '../character/session-store.js'
 import type { MemoryItem } from '../memory-store.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'retrieval' })
 
 // ─── Scoring Weights ──────────────────────────────────────────────────────────
 
@@ -134,7 +137,7 @@ export async function scoredMemorySearch(
     // Step 1 — Embed the query
     const queryEmbedding = await embed(query, 'retrieval.query')
     if (!queryEmbedding) {
-        console.warn('[archivist/retrieval] Embedding failed, skipping composite search')
+        log.warn('Embedding failed, skipping composite search')
         return []
     }
 

--- a/src/archivist/s3-archive.ts
+++ b/src/archivist/s3-archive.ts
@@ -11,6 +11,9 @@
  */
 
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 's3-archive' })
 
 // ─── S3 Client (lazy singleton) ───────────────────────────────────────────────
 
@@ -98,11 +101,11 @@ export async function archiveSession(
             })
         )
 
-        console.log(`[archivist/s3] Archived session ${sessionId} → s3://${bucket}/${s3Key}`)
+        log.info({ sessionId, bucket, s3Key }, 'Archived session')
         return { success: true, s3Key }
     } catch (err) {
         const msg = (err as Error).message
-        console.error(`[archivist/s3] Failed to archive session ${sessionId}:`, msg)
+        log.error({ err, sessionId }, 'Failed to archive session')
         return { success: false, error: msg }
     }
 }

--- a/src/archivist/session-summaries.ts
+++ b/src/archivist/session-summaries.ts
@@ -20,6 +20,9 @@ import { addMemories } from '../memory-store.js'
 import { archiveSession, type ArchivableMessage } from './s3-archive.js'
 import { withGroqRetry } from '../utils/retry.js'
 import { sanitizeInput } from '../character/sanitize.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'session-summaries' })
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -76,16 +79,13 @@ export async function checkAndSummarizeSessions(): Promise<void> {
 
     if (result.rows.length === 0) return
 
-    console.log(`[archivist/summarize] Found ${result.rows.length} session(s) to summarize`)
+    log.info({ count: result.rows.length }, 'Found sessions to summarize')
 
     for (const session of result.rows) {
         try {
             await summarizeSession(session)
         } catch (err) {
-            console.error(
-                `[archivist/summarize] Failed to summarize session ${session.sessionId}:`,
-                (err as Error).message
-            )
+            log.error({ err, sessionId: session.sessionId }, 'Failed to summarize session')
         }
     }
 }
@@ -111,7 +111,7 @@ export async function summarizeSession(session: SessionRow): Promise<string | nu
     // Step 2 — Generate summary with 8B LLM
     const summaryText = await generateSummary(userId, messages)
     if (!summaryText) {
-        console.warn(`[archivist/summarize] Empty summary for session ${sessionId}`)
+        log.warn({ sessionId }, 'Empty summary')
         return null
     }
 
@@ -146,8 +146,9 @@ export async function summarizeSession(session: SessionRow): Promise<string | nu
         [] // No history for the summary itself
     )
 
-    console.log(
-        `[archivist/summarize] Session ${sessionId} summarized (${messages.length} msgs → ${summaryText.length} chars)`
+    log.info(
+        { sessionId, messageCount: messages.length, summaryLength: summaryText.length },
+        'Session summarized',
     )
 
     return summaryText
@@ -221,7 +222,7 @@ async function generateSummary(
         const text = response.choices[0]?.message?.content?.trim()
         return text || null
     } catch (err) {
-        console.error('[archivist/summarize] LLM summarization failed:', (err as Error).message)
+        log.error({ err }, 'LLM summarization failed')
         return null
     }
 }

--- a/src/aws/aws-clients.ts
+++ b/src/aws/aws-clients.ts
@@ -1,4 +1,7 @@
 import { getAwsConfig } from './aws-config.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'aws-clients' })
 
 // ─── Subagent Type ───────────────────────────────────────────────────────────
 
@@ -71,10 +74,10 @@ export class AwsClientFactory {
                         { marshallOptions: { removeUndefinedValues: true, convertClassInstanceToMap: true } },
                     )
 
-                    console.log(`${this.tag('DynamoDB')} client initialized`)
+                    log.info(`${this.tag('DynamoDB')} client initialized`)
                     return this.dynamoDocClient
                 } catch (err) {
-                    console.error(`${this.tag('DynamoDB')} failed to initialize:`, err)
+                    log.error({ err }, `${this.tag('DynamoDB')} failed to initialize`)
                     this.dynamoDocClientInitPromise = null
                     return null
                 }
@@ -104,10 +107,10 @@ export class AwsClientFactory {
                         region: config.bedrock.region,
                         credentials: config.credentials ?? undefined,
                     })
-                    console.log(`${this.tag('Bedrock')} client initialized — region=${config.bedrock.region} model=${config.bedrock.modelId}`)
+                    log.info({ region: config.bedrock.region, modelId: config.bedrock.modelId }, `${this.tag('Bedrock')} client initialized`)
                     return this.bedrockClient
                 } catch (err) {
-                    console.error(`${this.tag('Bedrock')} failed to initialize:`, err)
+                    log.error({ err }, `${this.tag('Bedrock')} failed to initialize`)
                     this.bedrockInitPromise = null
                     return null
                 }
@@ -134,10 +137,10 @@ export class AwsClientFactory {
                 try {
                     const { SNSClient } = await import('@aws-sdk/client-sns')
                     this.snsClient = new SNSClient({ region: config.region, credentials: config.credentials ?? undefined })
-                    console.log(`${this.tag('SNS')} client initialized`)
+                    log.info(`${this.tag('SNS')} client initialized`)
                     return this.snsClient
                 } catch (err) {
-                    console.error(`${this.tag('SNS')} failed to initialize:`, err)
+                    log.error({ err }, `${this.tag('SNS')} failed to initialize`)
                     this.snsInitPromise = null
                     return null
                 }
@@ -164,10 +167,10 @@ export class AwsClientFactory {
                 try {
                     const { S3Client } = await import('@aws-sdk/client-s3')
                     this.s3Client = new S3Client({ region: config.region, credentials: config.credentials ?? undefined })
-                    console.log(`${this.tag('S3')} client initialized`)
+                    log.info(`${this.tag('S3')} client initialized`)
                     return this.s3Client
                 } catch (err) {
-                    console.error(`${this.tag('S3')} failed to initialize:`, err)
+                    log.error({ err }, `${this.tag('S3')} failed to initialize`)
                     this.s3InitPromise = null
                     return null
                 }
@@ -194,10 +197,10 @@ export class AwsClientFactory {
                 try {
                     const { CloudWatchClient } = await import('@aws-sdk/client-cloudwatch')
                     this.cloudwatchClient = new CloudWatchClient({ region: config.region, credentials: config.credentials ?? undefined })
-                    console.log(`${this.tag('CloudWatch')} client initialized`)
+                    log.info(`${this.tag('CloudWatch')} client initialized`)
                     return this.cloudwatchClient
                 } catch (err) {
-                    console.error(`${this.tag('CloudWatch')} failed to initialize:`, err)
+                    log.error({ err }, `${this.tag('CloudWatch')} failed to initialize`)
                     this.cloudwatchInitPromise = null
                     return null
                 }
@@ -224,10 +227,10 @@ export class AwsClientFactory {
                 try {
                     const { EventBridgeClient } = await import('@aws-sdk/client-eventbridge')
                     this.eventBridgeClient = new EventBridgeClient({ region: config.region, credentials: config.credentials ?? undefined })
-                    console.log(`${this.tag('EventBridge')} client initialized`)
+                    log.info(`${this.tag('EventBridge')} client initialized`)
                     return this.eventBridgeClient
                 } catch (err) {
-                    console.error(`${this.tag('EventBridge')} failed to initialize:`, err)
+                    log.error({ err }, `${this.tag('EventBridge')} failed to initialize`)
                     this.eventBridgeInitPromise = null
                     return null
                 }

--- a/src/aws/aws-config.ts
+++ b/src/aws/aws-config.ts
@@ -1,3 +1,7 @@
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'aws-config' })
+
 export interface AwsConfig {
   /** Whether AWS is configured (has credentials) */
   readonly enabled: boolean
@@ -130,9 +134,9 @@ export function getAwsConfig(): AwsConfig {
   if (!cached) {
     cached = loadConfig()
     if (cached.enabled) {
-      console.log(`[AWS] Configured — region=${cached.region}`)
+      log.info({ region: cached.region }, 'Configured')
     } else {
-      console.log('[AWS] Not configured — all services will use local fallbacks')
+      log.info('Not configured — all services will use local fallbacks')
     }
   }
   return cached

--- a/src/aws/cloudwatch-metrics.ts
+++ b/src/aws/cloudwatch-metrics.ts
@@ -1,5 +1,8 @@
 import { sharedClients } from './aws-clients.js'
 import { getAwsConfig } from './aws-config.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'cloudwatch-metrics' })
 
 // ─── Metric Names ─────────────────────────────────────────────────────────────
 
@@ -96,7 +99,7 @@ export async function publishMetric(
         }))
     } catch (err) {
         // Metric publishing should never break the main flow
-        console.error(`[CloudWatch] Failed to publish metric ${metricName}:`, err)
+        log.error({ err, metricName }, 'Failed to publish metric')
     }
 }
 
@@ -136,7 +139,7 @@ export async function publishMetrics(
             }))
         }
     } catch (err) {
-        console.error('[CloudWatch] Failed to publish metric batch:', err)
+        log.error({ err }, 'Failed to publish metric batch')
     }
 }
 
@@ -257,4 +260,3 @@ export function getDashboardBody(
 
     return JSON.stringify(dashboard)
 }
-

--- a/src/brain/index.ts
+++ b/src/brain/index.ts
@@ -5,6 +5,9 @@ import { reflectToolResult, buildSummaryForPrompt, buildFallbackMediaDirective }
 import { getWeatherState } from '../weather/weather-stimulus.js'
 import { getTrafficState } from '../stimulus/traffic-stimulus.js'
 import { getFestivalState } from '../stimulus/festival-stimulus.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'brain' })
 
 export const brainHooks: BrainHooks = {
     async routeMessage(context: RouteContext): Promise<RouteDecision> {
@@ -27,7 +30,7 @@ export const brainHooks: BrainHooks = {
                 decision.toolName = classification.tool_hint
                 decision.toolParams = args
             } else {
-                console.warn(`[brain] Classifier indicated tool '${classification.tool_hint}' but provided no tool_args for message`)
+                log.warn({ toolHint: classification.tool_hint }, 'Classifier indicated tool but provided no tool_args')
             }
         }
 
@@ -88,7 +91,7 @@ export const brainHooks: BrainHooks = {
                 mediaDirective,
             }
         } catch (error) {
-            console.error('[brain] Tool pipeline execution failed:', error)
+            log.error({ err: error }, 'Tool pipeline execution failed')
             return {
                 success: false,
                 data: 'Internal error executing tool',

--- a/src/brain/tool-reflection.ts
+++ b/src/brain/tool-reflection.ts
@@ -12,6 +12,9 @@ import Groq from 'groq-sdk'
 import type { ToolMediaDirective, ToolReflectionSummary } from '../hooks.js'
 import { withGroqRetry } from '../utils/retry.js'
 import { extractToolMediaContext } from '../media/tool-media-context.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'tool-reflection' })
 
 export interface ToolReflectionResult {
     reflection: ToolReflectionSummary
@@ -169,7 +172,7 @@ Rules:
         if (!reflected) return null
         return reflected
     } catch (err) {
-        console.warn(`[brain/reflection] ${toolName}: reflection failed, using fallback directive`, (err as Error).message)
+        log.warn({ toolName, err }, 'Reflection failed, using fallback directive')
         return {
             reflection: { summary: '', keyFacts: [] },
             mediaDirective: fallbackDirective,

--- a/src/channels.ts
+++ b/src/channels.ts
@@ -3,6 +3,10 @@
  * Supports: Telegram, WhatsApp, Slack (Discord coming soon)
  */
 
+import { logger } from './logger.js'
+
+const log = logger.child({ module: 'channels' })
+
 export interface ChannelMessage {
   channel: 'telegram' | 'whatsapp' | 'slack' | 'discord'
   userId: string      // Platform-specific user ID
@@ -102,7 +106,7 @@ export const telegramAdapter: ChannelAdapter = {
   sendMessage: async (chatId: string, text: string) => {
     const token = process.env.TELEGRAM_BOT_TOKEN
     if (!token) {
-      console.error('[Telegram] sendMessage failed: missing bot token')
+      log.error('sendMessage failed: missing bot token')
       return
     }
 
@@ -127,12 +131,12 @@ export const telegramAdapter: ChannelAdapter = {
         })
         const retryBody = await retryResp.json().catch(() => ({}))
         if (!retryResp.ok || retryBody?.ok === false) {
-          console.error('[Telegram] sendMessage retry failed:', (retryBody as any)?.description || retryResp.statusText)
+          log.error({ description: (retryBody as any)?.description || retryResp.statusText }, 'sendMessage retry failed')
         }
         return
       }
 
-      console.error('[Telegram] sendMessage failed:', description || resp.statusText)
+      log.error({ description: description || resp.statusText }, 'sendMessage failed')
     }
   },
 
@@ -149,7 +153,7 @@ export const telegramAdapter: ChannelAdapter = {
       if (downloaded) {
         const result = await uploadVideoToTelegram(chatId, downloaded, media[0].caption || '', { supportsStreaming: true })
         if (result.success) return
-        console.warn('[Telegram] sendMedia: multipart video upload failed, trying URL-based fallback')
+        log.warn('sendMedia: multipart video upload failed, trying URL-based fallback')
       }
 
       // For Places URLs, NEVER do URL-based fallback (produces map thumbnails)
@@ -174,7 +178,7 @@ export const telegramAdapter: ChannelAdapter = {
       })
       if (!resp.ok) {
         const err = await resp.json().catch(() => ({}))
-        console.error('[Telegram] sendVideo failed:', (err as any)?.description, 'url:', media[0].url)
+        log.error({ description: (err as any)?.description, url: media[0].url }, 'sendVideo failed')
         // Final fallback: send as URL in text message
         if (media[0].caption) {
           await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
@@ -194,7 +198,7 @@ export const telegramAdapter: ChannelAdapter = {
       if (downloaded) {
         const result = await uploadPhotoToTelegram(chatId, downloaded, media[0].caption || '')
         if (result.success) return
-        console.warn('[Telegram] sendMedia: multipart photo upload failed, trying URL-based fallback')
+        log.warn('sendMedia: multipart photo upload failed, trying URL-based fallback')
       }
 
       // For Places URLs, NEVER do URL-based fallback (produces map thumbnails)
@@ -218,7 +222,7 @@ export const telegramAdapter: ChannelAdapter = {
       })
       if (!resp.ok) {
         const err = await resp.json().catch(() => ({}))
-        console.error('[Telegram] sendPhoto failed:', (err as any)?.description, 'url:', media[0].url)
+        log.error({ description: (err as any)?.description, url: media[0].url }, 'sendPhoto failed')
       }
     } else {
       // Multiple photos — try downloading each and uploading individually
@@ -272,7 +276,7 @@ export const telegramAdapter: ChannelAdapter = {
           })
           if (!resp.ok) {
             const err = await resp.json().catch(() => ({}))
-            console.error('[Telegram] sendMediaGroup failed:', (err as any)?.description)
+            log.error({ description: (err as any)?.description }, 'sendMediaGroup failed')
           }
         }
       }
@@ -293,7 +297,7 @@ export async function sendProactiveContent(
 ): Promise<boolean> {
   const token = process.env.TELEGRAM_BOT_TOKEN
   if (!token) {
-    console.error('[Telegram] Cannot send proactive: no bot token')
+    log.error('Cannot send proactive: no bot token')
     return false
   }
 
@@ -311,18 +315,18 @@ export async function sendProactiveContent(
           : await uploadPhotoToTelegram(chatId, downloaded, caption)
 
         if (result.success) return true
-        console.warn('[Telegram] Multipart upload failed, trying URL-based fallback')
+        log.warn('Multipart upload failed, trying URL-based fallback')
       }
 
       // For Places URLs, NEVER do URL-based fallback (produces map thumbnails)
       if (isLikelyPlacesPhotoUrl(media.url)) {
-        console.warn('[Telegram] Skipping URL-based fallback for Places photo (would produce map thumbnail)')
+        log.warn('Skipping URL-based fallback for Places photo (would produce map thumbnail)')
         await telegramAdapter.sendMessage(chatId, caption)
         return true
       }
 
       // Fallback: try URL-based send (may fail for expired CDN URLs)
-      console.warn('[Telegram] Multipart upload failed, trying URL-based fallback')
+      log.warn('Multipart upload failed, trying URL-based fallback')
       const method = media.type === 'video' ? 'sendVideo' : 'sendPhoto'
       const field = media.type === 'video' ? 'video' : 'photo'
 
@@ -341,7 +345,7 @@ export async function sendProactiveContent(
       if (resp.ok) return true
 
       // Final fallback: send URL as text link
-      console.warn('[Telegram] URL-based send failed, sending as text')
+      log.warn('URL-based send failed, sending as text')
       await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -367,7 +371,7 @@ export async function sendProactiveContent(
       return data.ok === true
     }
   } catch (err) {
-    console.error('[Telegram] Proactive send failed:', err)
+    log.error({ err }, 'Proactive send failed')
     return false
   }
 }
@@ -450,11 +454,11 @@ export const whatsappAdapter: ChannelAdapter = {
 
       if (!resp.ok) {
         const err = await resp.json().catch(() => ({}))
-        console.error(`[WhatsApp] sendMedia failed (${mediaType}):`, (err as any)?.error?.message)
+        log.error({ mediaType, err: (err as any)?.error?.message }, 'WhatsApp sendMedia failed')
       }
     } catch (err: any) {
       // Network/transport error — non-fatal, text delivery continues unaffected
-      console.error(`[WhatsApp] sendMedia transport error:`, err?.message)
+      log.error({ err: err?.message }, 'WhatsApp sendMedia transport error')
     }
   },
 }

--- a/src/character/handler.ts
+++ b/src/character/handler.ts
@@ -84,6 +84,9 @@ import { handleOnboarding, type OnboardingResult } from '../onboarding/onboardin
 import { extractRejectionSignals, persistRejectionSignals, entityTypeToCategory } from '../intelligence/rejection-memory.js'
 import { resolveToolFromTopic } from '../topic-intent/tool-map.js'
 import { logExecutionBridge, logTopicCompleted } from '../topic-intent/logger.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'handler' })
 
 // Initialize Groq client
 const groq = new Groq({
@@ -400,7 +403,7 @@ function extractMediaFromToolResult(toolName: string | null | undefined, rawData
   const keys = data ? Object.keys(data) : []
   const hasImages = Array.isArray(data?.images)
   const imagesCount = hasImages ? data.images.length : 0
-  console.log(`[extractMedia] keys=${keys.join(',')} | hasImages=${hasImages} | imagesCount=${imagesCount} | firstImageUrl=${data?.images?.[0]?.url?.substring(0, 60) ?? 'N/A'}`)
+  log.debug({ keys, hasImages, imagesCount, firstImageUrl: data?.images?.[0]?.url?.substring(0, 60) ?? 'N/A' }, 'extractMedia diagnostic')
 
   // Grocery comparison: has a top-level images[] array with {url, caption}
   if (Array.isArray(data?.images)) {
@@ -574,7 +577,7 @@ export async function handleMessage(
     let onboardingResult: OnboardingResult | null = options.onboardingResult ?? null
     if (!options.bypassOnboarding && !user.authenticated) {
       onboardingResult = await handleOnboarding(user.userId, userMessage).catch(err => {
-        console.warn('[handler] Onboarding handling failed:', safeError(err))
+        log.warn({ err: safeError(err) }, 'Onboarding handling failed')
         return { handled: false as const }
       })
     }
@@ -602,7 +605,7 @@ export async function handleMessage(
     // classifier/memory pipeline. This avoids funnel-state collisions.
     if (channel === 'telegram' && !lightweightOnboarding) {
       const funnelReply = await handleFunnelReply(channelUserId, userMessage).catch(err => {
-        console.warn('[handler] Funnel reply handling failed, continuing normal pipeline:', safeError(err))
+        log.warn({ err: safeError(err) }, 'Funnel reply handling failed, continuing normal pipeline')
         return { handled: false as const }
       })
       if (funnelReply.handled) {
@@ -615,7 +618,7 @@ export async function handleMessage(
     // classifier/memory pipeline. Supports multi-step actionable flows.
     if (channel === 'telegram' && !lightweightOnboarding) {
       const taskReply = await handleTaskReply(channelUserId, userMessage).catch(err => {
-        console.warn('[handler] Task orchestrator reply handling failed, continuing normal pipeline:', safeError(err))
+        log.warn({ err: safeError(err) }, 'Task orchestrator reply handling failed, continuing normal pipeline')
         return { handled: false as const } as const
       })
       if (taskReply.handled && taskReply.response) {
@@ -651,14 +654,14 @@ export async function handleMessage(
       )
 
     if (!lightweightOnboarding) {
-      console.log('[handler] Classification:', {
+      log.info({
         complexity: classification.message_complexity,
         needsTool: classification.needs_tool,
         toolHint: classification.tool_hint,
         skipMemory: classification.skip_memory,
         skipGraph: classification.skip_graph,
         skipCognitive: classification.skip_cognitive,
-      })
+      }, 'Classification')
     }
 
     // ─── Rejection guard: clear parked tool + media context when user rejects ─
@@ -716,9 +719,9 @@ export async function handleMessage(
         classification.skip_memory
           ? Promise.resolve([])
           : scoredMemorySearch(searchUserIds.length > 1 ? searchUserIds : user.userId, memoryQuery, 5).catch(err => {
-            console.warn('[handler] Composite memory search failed, falling back to cosine:', safeError(err))
+            log.warn({ err: safeError(err) }, 'Composite memory search failed, falling back to cosine')
             return searchMemories(searchUserIds.length > 1 ? searchUserIds : user.userId, memoryQuery, 5).catch(err2 => {
-              console.error('[handler] Memory search failed:', safeError(err2))
+              log.error({ err: safeError(err2) }, 'Memory search failed')
               return [] as Awaited<ReturnType<typeof searchMemories>>
             })
           }),
@@ -726,22 +729,22 @@ export async function handleMessage(
         classification.skip_graph
           ? Promise.resolve([])
           : searchGraph(searchUserIds.length > 1 ? searchUserIds : user.userId, userMessage, 2, 10).catch(err => {
-            console.error('[handler] Graph search failed:', safeError(err))
+            log.error({ err: safeError(err) }, 'Graph search failed')
             return [] as Awaited<ReturnType<typeof searchGraph>>
           }),
         // Load user preferences
         loadPreferences(pool, user.userId).catch(err => {
-          console.error('[handler] Preferences load failed:', safeError(err))
+          log.error({ err: safeError(err) }, 'Preferences load failed')
           return {}
         }),
         // Fetch active conversation goal
         getActiveGoal(user.userId, session.sessionId).catch(err => {
-          console.error('[handler] Goal fetch failed:', safeError(err))
+          log.error({ err: safeError(err) }, 'Goal fetch failed')
           return null
         }),
         // Fetch agenda stack (top priorities) — separate from classifier activeGoal.
         agendaPlanner.getStack(user.userId, session.sessionId).catch(err => {
-          console.error('[handler] Agenda stack fetch failed:', safeError(err))
+          log.error({ err: safeError(err) }, 'Agenda stack fetch failed')
           return []
         }),
         // Pulse engagement state — non-blocking read from in-memory hot cache
@@ -783,10 +786,10 @@ export async function handleMessage(
           pulseScore: 0,
         })
           .then(output => {
-            console.log(`[Fusion/Reactive] user=${user.userId} route=${output.decision} confidence=${output.confidence.toFixed(2)} proactive=${output.proactiveContext?.length ?? 0} invalidated=${output.invalidatedStimuli.length}`)
+            log.info({ userId: user.userId, route: output.decision, confidence: output.confidence.toFixed(2), proactive: output.proactiveContext?.length ?? 0, invalidated: output.invalidatedStimuli.length }, 'Fusion/Reactive')
           })
-          .catch(err => console.error('[Fusion/Reactive] error:', (err as Error).message))
-      ).catch(err => console.error('[Fusion/Reactive] import error:', (err as Error).message))
+          .catch(err => log.error({ err: (err as Error).message }, 'Fusion/Reactive error'))
+      ).catch(err => log.error({ err: (err as Error).message }, 'Fusion/Reactive import error'))
     }
 
     // ─── Step 7: Brain hooks — route message (Dev 1) ──────────────
@@ -973,7 +976,7 @@ export async function handleMessage(
           }
 
         const proactiveResult = await brainHooks.executeToolPipeline(proactiveDecision, routeContext).catch(err => {
-          console.warn('[handler] Proactive onboarding tool call failed:', safeError(err))
+          log.warn({ err: safeError(err) }, 'Proactive onboarding tool call failed')
           return null
         })
 
@@ -1051,12 +1054,12 @@ export async function handleMessage(
         topicStrategy,
       })
     } catch (err) {
-      console.error('[handler] Personality composition failed, using static SOUL.md', safeError(err))
+      log.error({ err: safeError(err) }, 'Personality composition failed, using static SOUL.md')
       systemPromptComposed = getRawSoulPrompt()
     }
 
     // Structured logging for debug
-    console.log('[handler] Prompt composed', {
+    log.info({
       complexity: classification.message_complexity,
       prefCount: Object.keys(preferences).length,
       memoryCount: memories.length,
@@ -1068,7 +1071,7 @@ export async function handleMessage(
       pulseState: pulseEngagementState,
       hasToolResult: !!toolResultStr,
       promptLength: systemPromptComposed.length,
-    })
+    }, 'Prompt composed')
 
     // ─── Step 10: Build messages for Groq ─────────────────────────
     // Simple: 6 messages (3 exchanges) — no context needed for "hi", "ok", "thanks"
@@ -1091,7 +1094,7 @@ export async function handleMessage(
     let estimatedTokens = estimateTokens(messages)
 
     if (estimatedTokens > MAX_PROMPT_TOKENS) {
-      console.warn(`[handler] Prompt too large (~${Math.round(estimatedTokens)} tokens). Truncating...`)
+      log.warn({ estimatedTokens: Math.round(estimatedTokens) }, 'Prompt too large, truncating')
 
       // Strategy 1: Truncate tool results in the system prompt (biggest offender)
       if (toolResultStr && toolResultStr.length > 800) {
@@ -1125,7 +1128,7 @@ export async function handleMessage(
         estimatedTokens = estimateTokens(messages)
       }
 
-      console.log(`[handler] After truncation: ~${Math.round(estimatedTokens)} tokens, history=${historyLimit}`)
+      log.info({ estimatedTokens: Math.round(estimatedTokens), historyLimit }, 'After truncation')
     }
 
     // ─── Step 11: Call Tier 2 (70B) + inline media fetch — truly concurrent ──
@@ -1183,7 +1186,7 @@ export async function handleMessage(
       ]),
     ])
 
-    console.log(`[handler] Tier 2 response from ${tier2Provider}${inlineMediaItem ? ` | inline media: ${inlineMediaItem.type}` : ''}`)
+    log.info({ tier2Provider, inlineMediaType: inlineMediaItem?.type ?? null }, 'Tier 2 response')
 
     let rawResponse = tier2Response
 
@@ -1205,22 +1208,22 @@ export async function handleMessage(
       const questionLikeCount = countQuestionLikeSentences(generated)
       const severeStepDrift = generated.length > 560 || questionLikeCount > 1
       if (severeStepDrift) {
-        console.warn('[handler] Onboarding drift fallback applied', {
+        log.warn({
           userId: user.userId,
           generatedLength: generated.length,
           questionLikeCount,
           preview: generated.slice(0, 140),
-        })
+        }, 'Onboarding drift fallback applied')
         assistantResponse = onboardingResult.reply
       }
     }
 
     if (needsHumanReview(filterResult)) {
-      console.error('[SECURITY] Output filtered for review:', {
+      log.error({
         userId: user.userId,
         reason: filterResult.reason,
         originalPreview: rawResponse.slice(0, 200),
-      })
+      }, 'Output filtered for review')
     }
 
     // ─── Step 14: Store messages in session ────────────────────────
@@ -1237,7 +1240,7 @@ export async function handleMessage(
     // bias the first real conversational turn after onboarding completes.
     if (onboardingActive && onboardingResult?.onboardingCompleted) {
       await clearSessionMessages(session.sessionId).catch(err => {
-        console.warn('[handler] Failed to clear onboarding session history:', safeError(err))
+        log.warn({ err: safeError(err) }, 'Failed to clear onboarding session history')
       })
     }
 
@@ -1276,7 +1279,7 @@ export async function handleMessage(
             userMessage,
             classification,
           ).catch(err => {
-            console.error('[handler] Topic intent processing failed:', err)
+            log.error({ err }, 'Topic intent processing failed')
           })
         }
 
@@ -1286,7 +1289,7 @@ export async function handleMessage(
           topicIntentService.completeTopic(user.userId, executingTopic.id)
             .then(() => logTopicCompleted(user.userId, executingTopic!.id, executingTopic!.topic))
             .catch(err => {
-              console.error('[handler] Topic completion failed:', err)
+              log.error({ err }, 'Topic completion failed')
             })
         }
 
@@ -1297,7 +1300,7 @@ export async function handleMessage(
           previousMessageAt,
           classifierSignal: classification.userSignal,
         }).catch(err => {
-          console.error('[handler] Pulse scoring failed:', safeError(err))
+          log.error({ err: safeError(err) }, 'Pulse scoring failed')
         })
 
         agendaPlanner.evaluate({
@@ -1312,7 +1315,7 @@ export async function handleMessage(
           activeToolName: routeDecision?.toolName ?? undefined,
           hasToolResult: !!toolResultStr,
         }).catch(err => {
-          console.error('[handler] Agenda planner evaluation failed:', safeError(err))
+          log.error({ err: safeError(err) }, 'Agenda planner evaluation failed')
         })
       })
     }
@@ -1389,9 +1392,9 @@ export async function handleMessage(
         : (toolExtractedMedia ?? fallbackMediaFromContext ?? venuePreviewMedia))
 
     // Diagnostic logging for media pipeline
-    console.log(`[handler] Media pipeline: toolName=${routeDecision.toolName} | inlineMediaItem=${!!inlineMediaItem} | toolExtracted=${toolExtractedMedia?.length ?? 0} | fallbackFromCtx=${fallbackMediaFromContext?.length ?? 0} | venuePreview=${venuePreviewMedia?.length ?? 0} | final=${resolvedMedia?.length ?? 0}`)
+    log.debug({ toolName: routeDecision.toolName, inlineMediaItem: !!inlineMediaItem, toolExtracted: toolExtractedMedia?.length ?? 0, fallbackFromCtx: fallbackMediaFromContext?.length ?? 0, venuePreview: venuePreviewMedia?.length ?? 0, final: resolvedMedia?.length ?? 0 }, 'Media pipeline')
     if (resolvedMedia?.length) {
-      console.log(`[handler] Media URLs: ${resolvedMedia.map(m => m.url?.substring(0, 80)).join(' | ')}`)
+      log.debug({ urls: resolvedMedia.map(m => m.url?.substring(0, 80)) }, 'Media URLs')
     }
 
     return {
@@ -1405,7 +1408,7 @@ export async function handleMessage(
     }
 
   } catch (error) {
-    console.error('[ERROR] Message handling failed:', safeError(error))
+    log.error({ err: safeError(error) }, 'Message handling failed')
     return { text: "Oops, something went wrong on my end! Mind trying that again? 😅" }
   }
 }
@@ -1483,7 +1486,7 @@ async function handleFriendCommand(
 
     return '👥 **Friend Commands:**\n`/friend` — list friends\n`/friend add <username>` — add friend\n`/friend remove <username>` — remove friend\n`/friend accept <username>` — accept request'
   } catch (error) {
-    console.error('[handler] Friend command failed:', safeError(error))
+    log.error({ err: safeError(error) }, 'Friend command failed')
     return "Something went wrong with the friend command. Please try again!"
   }
 }
@@ -1564,7 +1567,7 @@ async function handleSquadCommand(
 
     return '👥 **Squad Commands:**\n`/squad` — list squads\n`/squad create <name>` — create squad\n`/squad invite <squad> <user>` — invite member\n`/squad join <name>` — accept invite\n`/squad leave <name>` — leave squad'
   } catch (error) {
-    console.error('[handler] Squad command failed:', safeError(error))
+    log.error({ err: safeError(error) }, 'Squad command failed')
     return "Something went wrong with the squad command. Please try again!"
   }
 }
@@ -1593,7 +1596,7 @@ async function handleLinkCommand(
     }
     return result.message
   } catch (error) {
-    console.error('[handler] Link command failed:', safeError(error))
+    log.error({ err: safeError(error) }, 'Link command failed')
     return "Something went wrong with the link command. Please try again!"
   }
 }

--- a/src/character/output-filter.ts
+++ b/src/character/output-filter.ts
@@ -3,6 +3,10 @@
  * Detect and filter anomalous or potentially harmful responses
  */
 
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'output-filter' })
+
 // Patterns that should never appear in Aria's responses
 const FORBIDDEN_OUTPUT_PATTERNS = [
   // System prompt leakage
@@ -83,7 +87,7 @@ export function filterOutput(output: string): OutputFilterResult {
 
   // Only flag if it's a long response that sounds nothing like Aria
   if (output.length > 200 && !hasAriaVoice) {
-    console.warn('[OUTPUT] Response may be off-character:', output.slice(0, 100))
+    log.warn({ preview: output.slice(0, 100) }, 'Response may be off-character')
     // Don't filter, just log - could be a valid edge case
   }
 

--- a/src/character/sanitize.ts
+++ b/src/character/sanitize.ts
@@ -3,6 +3,10 @@
  * Multi-layer defense against prompt injection
  */
 
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'sanitize' })
+
 // Maximum allowed message length
 const MAX_MESSAGE_LENGTH = 500
 
@@ -124,12 +128,11 @@ export function logSuspiciousInput(
   result: SanitizationResult
 ): void {
   if (result.suspiciousPatterns.length > 0) {
-    console.warn('[SECURITY] Suspicious input detected', {
+    log.warn({
       userId,
       channel,
       patterns: result.suspiciousPatterns,
       inputPreview: originalInput.slice(0, 100),
-      timestamp: new Date().toISOString(),
-    })
+    }, 'Suspicious input detected')
   }
 }

--- a/src/character/session-store.ts
+++ b/src/character/session-store.ts
@@ -4,6 +4,9 @@
  */
 
 import { Pool, PoolClient } from 'pg'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'session-store' })
 
 // Types
 export interface User {
@@ -340,7 +343,7 @@ export async function runMigrations(): Promise<void> {
     END $$
   `)
 
-  console.log('[DB] Migrations complete')
+  log.info('Migrations complete')
 }
 
 /**

--- a/src/cognitive.ts
+++ b/src/cognitive.ts
@@ -30,6 +30,9 @@ import { withGroqRetry } from './utils/retry.js'
 import { getWeatherState } from './weather/weather-stimulus.js'
 import { getTrafficState } from './stimulus/traffic-stimulus.js'
 import { getFestivalState } from './stimulus/festival-stimulus.js'
+import { logger } from './logger.js'
+
+const log = logger.child({ module: 'cognitive' })
 
 // ─── Type Coercion Helper ───────────────────────────────────────────────────
 // Groq 8B sometimes emits numbers as strings (e.g. "amount": "100").
@@ -223,7 +226,7 @@ export async function classifyMessage(
             try {
                 toolArgs = JSON.parse(toolCall.function.arguments)
             } catch {
-                console.warn('[cognitive] Failed to parse tool_call arguments:', toolCall.function.arguments)
+                log.warn({ arguments: toolCall.function.arguments }, 'Failed to parse tool_call arguments')
             }
 
             toolArgs = coerceToolArgs(toolName, toolArgs)
@@ -310,7 +313,7 @@ export async function classifyMessage(
                 let toolArgs: Record<string, unknown> = {}
                 try { toolArgs = JSON.parse(match[2]) } catch { /* best effort */ }
                 toolArgs = coerceToolArgs(toolName, toolArgs)
-                console.log(`[cognitive] Recovered tool call from failed_generation: ${toolName}`, toolArgs)
+                log.info({ toolName, toolArgs }, 'Recovered tool call from failed_generation')
                 return {
                     message_complexity: 'complex',
                     needs_tool: true,
@@ -330,9 +333,9 @@ export async function classifyMessage(
         }
         // Rate-limit exhaustion — log cleanly instead of dumping full error
         if (error?.status === 429) {
-            console.warn('[cognitive] Classifier rate-limited after all retries, using default classification')
+            log.warn('Classifier rate-limited after all retries, using default classification')
         } else {
-            console.error('[cognitive] Classification failed, using defaults:', error)
+            log.error({ err: error }, 'Classification failed, using defaults')
         }
         return getDefaultClassification()
     }
@@ -428,7 +431,7 @@ export async function updateConversationGoal(
         )
         return result.rows[0] || null
     } catch (error) {
-        console.error('[cognitive] Goal update failed:', error)
+        log.error({ err: error }, 'Goal update failed')
         return null
     }
 }
@@ -453,7 +456,7 @@ export async function getActiveGoal(
         )
         return result.rows[0] || null
     } catch (error) {
-        console.error('[cognitive] Goal fetch failed:', error)
+        log.error({ err: error }, 'Goal fetch failed')
         return null
     }
 }

--- a/src/intelligence/bedrock-extractor.ts
+++ b/src/intelligence/bedrock-extractor.ts
@@ -12,6 +12,9 @@ import { getAwsConfig } from '../aws/aws-config.js'
 import { publishMetric, subagentDimension } from '../aws/cloudwatch-metrics.js'
 import { sanitizeInput } from '../character/sanitize.js'
 import type { RejectedEntity, PreferredEntity } from './rejection-memory.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'bedrock-extractor' })
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -155,7 +158,7 @@ Assistant reply: "${assistantReply.slice(0, 400)}"`,
         }
     } catch (err) {
         const latencyMs = Date.now() - startMs
-        console.error(`[Bedrock/Extractor] Signal extraction failed (${latencyMs}ms):`, (err as Error).message)
+        log.error({ latencyMs, err }, 'Signal extraction failed')
         return null // Caller falls back to Groq
     }
 }

--- a/src/llm/provider-router.ts
+++ b/src/llm/provider-router.ts
@@ -1,0 +1,142 @@
+/**
+ * ProviderRouter — Circuit-breaker fallback chain for LLM providers.
+ *
+ * Tries each provider in order. Tracks errors per provider in a rolling
+ * 60-second window. A provider is "tripped" (skipped) when it accumulates
+ * more than ERROR_THRESHOLD errors within the window.
+ *
+ * Tripped providers are automatically reset after the window expires,
+ * giving them a chance to recover before being tried again.
+ *
+ * Usage:
+ *   const router = new ProviderRouter([togetherProvider, fireworksProvider])
+ *   const response = await router.chatWithTools(params)  // auto-fails over on error
+ */
+
+import { logger as rootLogger } from '../logger.js'
+import type { LLMProviderWithTools, ChatParams, ChatResponse, ToolChatParams, ToolChatResponse } from './providers/types.js'
+
+const log = rootLogger.child({ module: 'provider-router' })
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const ERROR_THRESHOLD = 5
+const WINDOW_MS = 60_000
+
+// ─── Internal State ──────────────────────────────────────────────────────────
+
+interface ProviderState {
+    provider: LLMProviderWithTools
+    errorCount: number
+    windowStart: number
+    tripped: boolean
+}
+
+// ─── ProviderRouter ──────────────────────────────────────────────────────────
+
+export class ProviderRouter implements LLMProviderWithTools {
+    name = 'provider-router'
+
+    private readonly states: ProviderState[]
+    private readonly errorThreshold: number
+    private readonly windowMs: number
+
+    constructor(
+        providers: LLMProviderWithTools[],
+        opts?: { errorThreshold?: number; windowMs?: number }
+    ) {
+        if (providers.length === 0) throw new Error('[ProviderRouter] At least one provider required')
+
+        this.errorThreshold = opts?.errorThreshold ?? ERROR_THRESHOLD
+        this.windowMs = opts?.windowMs ?? WINDOW_MS
+        this.states = providers.map(p => ({
+            provider: p,
+            errorCount: 0,
+            windowStart: Date.now(),
+            tripped: false,
+        }))
+    }
+
+    async isAvailable(): Promise<boolean> {
+        for (const state of this.states) {
+            if (await state.provider.isAvailable()) return true
+        }
+        return false
+    }
+
+    async chat(params: ChatParams): Promise<ChatResponse> {
+        let lastErr: Error | undefined
+
+        for (const state of this.states) {
+            if (this.isTripped(state)) {
+                log.debug({ provider: state.provider.name }, 'circuit open — skipping provider')
+                continue
+            }
+            if (!await state.provider.isAvailable()) continue
+
+            try {
+                return await state.provider.chat(params)
+            } catch (err) {
+                lastErr = err as Error
+                this.recordError(state)
+                log.warn({ provider: state.provider.name, errorCount: state.errorCount, err }, 'provider error — trying next')
+            }
+        }
+
+        throw new Error(`[ProviderRouter] All providers failed or tripped: ${lastErr?.message ?? 'unknown'}`)
+    }
+
+    async chatWithTools(params: ToolChatParams): Promise<ToolChatResponse> {
+        let lastErr: Error | undefined
+
+        for (const state of this.states) {
+            if (this.isTripped(state)) {
+                log.debug({ provider: state.provider.name }, 'circuit open — skipping provider')
+                continue
+            }
+            if (!await state.provider.isAvailable()) continue
+
+            try {
+                return await state.provider.chatWithTools(params)
+            } catch (err) {
+                lastErr = err as Error
+                this.recordError(state)
+                log.warn({ provider: state.provider.name, errorCount: state.errorCount, err }, 'provider error — trying next')
+            }
+        }
+
+        throw new Error(`[ProviderRouter] All providers failed or tripped: ${lastErr?.message ?? 'unknown'}`)
+    }
+
+    // ─── Circuit Breaker ──────────────────────────────────────────────────────
+
+    private resetIfExpired(state: ProviderState): void {
+        if (Date.now() - state.windowStart > this.windowMs) {
+            if (state.tripped) {
+                log.info({ provider: state.provider.name }, 'circuit reset — window expired')
+            }
+            state.errorCount = 0
+            state.windowStart = Date.now()
+            state.tripped = false
+        }
+    }
+
+    private recordError(state: ProviderState): void {
+        this.resetIfExpired(state)
+        state.errorCount++
+        if (state.errorCount >= this.errorThreshold) {
+            if (!state.tripped) {
+                log.warn(
+                    { provider: state.provider.name, errorCount: state.errorCount, thresholdMs: this.windowMs },
+                    'circuit tripped — provider will be skipped until window resets'
+                )
+            }
+            state.tripped = true
+        }
+    }
+
+    private isTripped(state: ProviderState): boolean {
+        this.resetIfExpired(state)
+        return state.tripped
+    }
+}

--- a/src/llm/providers/fireworks.ts
+++ b/src/llm/providers/fireworks.ts
@@ -81,7 +81,8 @@ export class FireworksProvider implements LLMProviderWithTools {
             tool_choice: params.toolChoice ?? 'auto',
             max_tokens: params.maxTokens ?? DEFAULT_MAX_TOKENS,
             temperature: params.temperature ?? DEFAULT_TEMPERATURE,
-            parallel_tool_calls: params.parallelToolCalls ?? true,
+            // parallel_tool_calls is NOT forwarded — Fireworks Llama models silently
+            // drop tool_calls and return plain text when this field is present.
         }
 
         const data = await fireworksFetch('/chat/completions', body)

--- a/src/llm/providers/fireworks.ts
+++ b/src/llm/providers/fireworks.ts
@@ -1,0 +1,161 @@
+/**
+ * Fireworks AI Provider — raw fetch, no SDK dependency.
+ *
+ * Used as a fallback provider when Together AI is unavailable.
+ * Fireworks exposes an OpenAI-compatible REST API.
+ *
+ * Model: accounts/fireworks/models/llama-v3p1-70b-instruct (default)
+ * Docs:  https://readme.fireworks.ai/reference/createchatcompletion
+ */
+
+import { logger as rootLogger } from '../../logger.js'
+import type {
+    LLMProviderWithTools,
+    ChatParams,
+    ChatResponse,
+    ToolChatParams,
+    ToolChatResponse,
+    ToolCallResult,
+} from './types.js'
+
+const log = rootLogger.child({ module: 'fireworks' })
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const BASE_URL = 'https://api.fireworks.ai/inference/v1'
+const DEFAULT_MODEL = process.env.FIREWORKS_MODEL ?? 'accounts/fireworks/models/llama-v3p1-70b-instruct'
+const DEFAULT_MAX_TOKENS = 1024
+const DEFAULT_TEMPERATURE = 0.3
+const TIMEOUT_MS = 30_000
+
+// ─── Fireworks Provider ──────────────────────────────────────────────────────
+
+export class FireworksProvider implements LLMProviderWithTools {
+    name = 'fireworks'
+
+    async isAvailable(): Promise<boolean> {
+        return !!process.env.FIREWORKS_API_KEY
+    }
+
+    async chat(params: ChatParams): Promise<ChatResponse> {
+        const start = Date.now()
+        const messages = buildMessages(params.messages, params.systemPrompt)
+
+        const body: Record<string, unknown> = {
+            model: params.model || DEFAULT_MODEL,
+            messages,
+            max_tokens: params.maxTokens ?? DEFAULT_MAX_TOKENS,
+            temperature: params.temperature ?? DEFAULT_TEMPERATURE,
+        }
+
+        if (params.jsonMode) {
+            body.response_format = { type: 'json_object' }
+        }
+
+        const data = await fireworksFetch('/chat/completions', body)
+        const content: string = data.choices?.[0]?.message?.content || ''
+        const usage = {
+            inputTokens: data.usage?.prompt_tokens || 0,
+            outputTokens: data.usage?.completion_tokens || 0,
+        }
+
+        log.debug({ inputTokens: usage.inputTokens, outputTokens: usage.outputTokens, latencyMs: Date.now() - start }, 'chat complete')
+        return { content, usage, latencyMs: Date.now() - start }
+    }
+
+    async chatWithTools(params: ToolChatParams): Promise<ToolChatResponse> {
+        const start = Date.now()
+        const messages = buildMessages(params.messages, params.systemPrompt)
+
+        const body: Record<string, unknown> = {
+            model: params.model || DEFAULT_MODEL,
+            messages,
+            tools: params.tools.map(t => ({
+                type: 'function',
+                function: {
+                    name: t.function.name,
+                    description: t.function.description,
+                    parameters: t.function.parameters,
+                },
+            })),
+            tool_choice: params.toolChoice ?? 'auto',
+            max_tokens: params.maxTokens ?? DEFAULT_MAX_TOKENS,
+            temperature: params.temperature ?? DEFAULT_TEMPERATURE,
+            parallel_tool_calls: params.parallelToolCalls ?? true,
+        }
+
+        const data = await fireworksFetch('/chat/completions', body)
+        const choice = data.choices?.[0]
+        const content: string = choice?.message?.content || ''
+
+        const toolCalls: ToolCallResult[] = (choice?.message?.tool_calls || []).map((tc: any) => ({
+            id: tc.id,
+            function: {
+                name: tc.function.name,
+                arguments: tc.function.arguments,
+            },
+        }))
+
+        const stopReason: ToolChatResponse['stopReason'] =
+            choice?.finish_reason === 'tool_calls' ? 'tool_use'
+            : choice?.finish_reason === 'length' ? 'length'
+            : 'stop'
+
+        const usage = {
+            inputTokens: data.usage?.prompt_tokens || 0,
+            outputTokens: data.usage?.completion_tokens || 0,
+        }
+
+        log.debug({ tools: toolCalls.length, inputTokens: usage.inputTokens, outputTokens: usage.outputTokens, latencyMs: Date.now() - start }, 'chatWithTools complete')
+        return { content, toolCalls, stopReason, usage, latencyMs: Date.now() - start }
+    }
+}
+
+// ─── HTTP Client ────────────────────────────────────────────────────────────
+
+async function fireworksFetch(path: string, body: Record<string, unknown>): Promise<any> {
+    const apiKey = process.env.FIREWORKS_API_KEY
+    if (!apiKey) throw new Error('[Fireworks] FIREWORKS_API_KEY not set')
+
+    const resp = await fetch(`${BASE_URL}${path}`, {
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+    })
+
+    if (!resp.ok) {
+        const rawErr = await resp.text().catch(() => '')
+        const safeErr = rawErr.replace(/Bearer\s+[^\s"]+/gi, 'Bearer [redacted]').slice(0, 200)
+        const error = new Error(`[Fireworks] ${resp.status}: ${safeErr}`) as any
+        error.status = resp.status
+        throw error
+    }
+
+    return resp.json()
+}
+
+function buildMessages(
+    messages: ChatParams['messages'],
+    systemPrompt?: string
+): Array<Record<string, unknown>> {
+    const result: Array<Record<string, unknown>> = []
+
+    if (systemPrompt) {
+        result.push({ role: 'system', content: systemPrompt })
+    }
+
+    for (const msg of messages) {
+        if (msg.role === 'system' && systemPrompt) continue
+        result.push({
+            role: msg.role,
+            content: msg.content,
+            ...(msg.tool_call_id ? { tool_call_id: msg.tool_call_id } : {}),
+        })
+    }
+
+    return result
+}

--- a/src/llm/providers/together.ts
+++ b/src/llm/providers/together.ts
@@ -1,0 +1,163 @@
+/**
+ * Together AI Real-time Provider — raw fetch, no SDK dependency.
+ *
+ * Used by:
+ *   - Sentinel Phase 2 fallback (when Bedrock is unavailable)
+ *   - Sentinel Phase 1 concurrent scoring (small batches < threshold)
+ *   - Alpha reactive chat (#140 — same file, same interface, zero merge conflict)
+ *
+ * Together exposes an OpenAI-compatible REST API.
+ * Model: meta-llama/Llama-3.3-70B-Instruct-Turbo (default)
+ */
+
+import { logger as rootLogger } from '../../logger.js'
+import type {
+    LLMProviderWithTools,
+    ChatParams,
+    ChatResponse,
+    ToolChatParams,
+    ToolChatResponse,
+    ToolCallResult,
+} from './types.js'
+
+const log = rootLogger.child({ module: 'together' })
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const BASE_URL = 'https://api.together.xyz/v1'
+const DEFAULT_MODEL = process.env.TOGETHER_CHAT_MODEL ?? 'meta-llama/Llama-3.3-70B-Instruct-Turbo'
+const DEFAULT_MAX_TOKENS = 1024
+const DEFAULT_TEMPERATURE = 0.3
+const TIMEOUT_MS = 30_000
+
+// ─── Together Provider ──────────────────────────────────────────────────────
+
+export class TogetherProvider implements LLMProviderWithTools {
+    name = 'together'
+
+    async isAvailable(): Promise<boolean> {
+        return !!process.env.TOGETHER_API_KEY
+    }
+
+    async chat(params: ChatParams): Promise<ChatResponse> {
+        const start = Date.now()
+        const messages = buildMessages(params.messages, params.systemPrompt)
+
+        const body: Record<string, unknown> = {
+            model: params.model || DEFAULT_MODEL,
+            messages,
+            max_tokens: params.maxTokens ?? DEFAULT_MAX_TOKENS,
+            temperature: params.temperature ?? DEFAULT_TEMPERATURE,
+        }
+
+        if (params.jsonMode) {
+            body.response_format = { type: 'json_object' }
+        }
+
+        const data = await togetherFetch('/chat/completions', body)
+        const content: string = data.choices?.[0]?.message?.content || ''
+        const usage = {
+            inputTokens: data.usage?.prompt_tokens || 0,
+            outputTokens: data.usage?.completion_tokens || 0,
+        }
+
+        log.debug({ inputTokens: usage.inputTokens, outputTokens: usage.outputTokens, latencyMs: Date.now() - start }, 'chat complete')
+        return { content, usage, latencyMs: Date.now() - start }
+    }
+
+    async chatWithTools(params: ToolChatParams): Promise<ToolChatResponse> {
+        const start = Date.now()
+        const messages = buildMessages(params.messages, params.systemPrompt)
+
+        const body: Record<string, unknown> = {
+            model: params.model || DEFAULT_MODEL,
+            messages,
+            tools: params.tools.map(t => ({
+                type: 'function',
+                function: {
+                    name: t.function.name,
+                    description: t.function.description,
+                    parameters: t.function.parameters,
+                },
+            })),
+            tool_choice: params.toolChoice ?? 'auto',
+            max_tokens: params.maxTokens ?? DEFAULT_MAX_TOKENS,
+            temperature: params.temperature ?? DEFAULT_TEMPERATURE,
+            parallel_tool_calls: params.parallelToolCalls ?? true,
+        }
+
+        const data = await togetherFetch('/chat/completions', body)
+        const choice = data.choices?.[0]
+        const content: string = choice?.message?.content || ''
+
+        const toolCalls: ToolCallResult[] = (choice?.message?.tool_calls || []).map((tc: any) => ({
+            id: tc.id,
+            function: {
+                name: tc.function.name,
+                arguments: tc.function.arguments,
+            },
+        }))
+
+        const stopReason: ToolChatResponse['stopReason'] =
+            choice?.finish_reason === 'tool_calls' ? 'tool_use'
+            : choice?.finish_reason === 'length' ? 'length'
+            : 'stop'
+
+        const usage = {
+            inputTokens: data.usage?.prompt_tokens || 0,
+            outputTokens: data.usage?.completion_tokens || 0,
+        }
+
+        log.debug({ tools: toolCalls.length, inputTokens: usage.inputTokens, outputTokens: usage.outputTokens, latencyMs: Date.now() - start }, 'chatWithTools complete')
+        return { content, toolCalls, stopReason, usage, latencyMs: Date.now() - start }
+    }
+}
+
+// ─── HTTP Client ────────────────────────────────────────────────────────────
+
+async function togetherFetch(path: string, body: Record<string, unknown>): Promise<any> {
+    const apiKey = process.env.TOGETHER_API_KEY
+    if (!apiKey) throw new Error('[Together] TOGETHER_API_KEY not set')
+
+    const resp = await fetch(`${BASE_URL}${path}`, {
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+    })
+
+    if (!resp.ok) {
+        const rawErr = await resp.text().catch(() => '')
+        const safeErr = rawErr.replace(/Bearer\s+[^\s"]+/gi, 'Bearer [redacted]').slice(0, 200)
+        const error = new Error(`[Together] ${resp.status}: ${safeErr}`) as any
+        error.status = resp.status
+        throw error
+    }
+
+    return resp.json()
+}
+
+function buildMessages(
+    messages: ChatParams['messages'],
+    systemPrompt?: string
+): Array<Record<string, unknown>> {
+    const result: Array<Record<string, unknown>> = []
+
+    if (systemPrompt) {
+        result.push({ role: 'system', content: systemPrompt })
+    }
+
+    for (const msg of messages) {
+        if (msg.role === 'system' && systemPrompt) continue
+        result.push({
+            role: msg.role,
+            content: msg.content,
+            ...(msg.tool_call_id ? { tool_call_id: msg.tool_call_id } : {}),
+        })
+    }
+
+    return result
+}

--- a/src/llm/providers/types.ts
+++ b/src/llm/providers/types.ts
@@ -1,0 +1,83 @@
+/**
+ * Shared types for LLM providers (Together, Fireworks, Bedrock, etc.)
+ *
+ * All providers in src/llm/providers/ implement these interfaces.
+ * ProviderRouter and higher-level wrappers (AlphaProvider, SentinelProvider)
+ * depend only on these contracts, not on concrete implementations.
+ */
+
+// ─── Message Types ────────────────────────────────────────────────────────────
+
+export interface ProviderMessage {
+    role: 'system' | 'user' | 'assistant' | 'tool'
+    content: string
+    /** Present on tool-result messages */
+    tool_call_id?: string
+}
+
+// ─── Tool Schema (Groq / OpenAI compatible) ───────────────────────────────────
+
+export interface ToolFunction {
+    name: string
+    description: string
+    parameters: Record<string, unknown>
+}
+
+export interface ProviderTool {
+    type: 'function'
+    function: ToolFunction
+}
+
+export interface ToolCallResult {
+    id: string
+    function: {
+        name: string
+        /** Raw JSON string of arguments */
+        arguments: string
+    }
+}
+
+// ─── Request Params ───────────────────────────────────────────────────────────
+
+export interface ChatParams {
+    messages: ProviderMessage[]
+    systemPrompt?: string
+    model?: string
+    maxTokens?: number
+    temperature?: number
+    /** Force the model to return a JSON object */
+    jsonMode?: boolean
+}
+
+export interface ToolChatParams extends ChatParams {
+    tools: ProviderTool[]
+    toolChoice?: 'auto' | 'none' | 'required'
+    parallelToolCalls?: boolean
+}
+
+// ─── Response Types ───────────────────────────────────────────────────────────
+
+export interface UsageStats {
+    inputTokens: number
+    outputTokens: number
+}
+
+export interface ChatResponse {
+    content: string
+    usage: UsageStats
+    latencyMs: number
+}
+
+export interface ToolChatResponse extends ChatResponse {
+    toolCalls: ToolCallResult[]
+    stopReason: 'stop' | 'tool_use' | 'length'
+}
+
+// ─── Provider Interface ───────────────────────────────────────────────────────
+
+export interface LLMProviderWithTools {
+    name: string
+    isAvailable(): Promise<boolean>
+    chat(params: ChatParams): Promise<ChatResponse>
+    chatWithTools(params: ToolChatParams): Promise<ToolChatResponse>
+}

--- a/src/llm/tierManager.ts
+++ b/src/llm/tierManager.ts
@@ -13,6 +13,9 @@
 
 import Groq from 'groq-sdk'
 import { withGroqRetry } from '../utils/retry.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'tier-manager' })
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -177,7 +180,7 @@ async function callWithFallback(
 
         for (let attempt = 0; attempt < BACKOFF_DELAYS.length; attempt++) {
             try {
-                console.log(`[LLM] Using ${provider.name} (${tier})`)
+                log.info({ provider: provider.name, tier }, 'Using provider')
                 const text = await provider.call(messages, opts)
                 return { text, provider: provider.name }
             } catch (err: any) {
@@ -189,30 +192,30 @@ async function callWithFallback(
                 if (is429) {
                     if (attempt < BACKOFF_DELAYS.length - 1) {
                         const delay = BACKOFF_DELAYS[attempt]
-                        console.warn(`[LLM] ${provider.name} rate-limited, retrying in ${delay}ms (attempt ${attempt + 1})`)
+                        log.warn({ provider: provider.name, delay, attempt: attempt + 1 }, 'Rate-limited, retrying')
                         await sleep(delay)
                         continue
                     }
                     // Exhausted retries for this provider → fallback to next
-                    console.warn(`[LLM] ${provider.name} exhausted, falling back to next provider`)
+                    log.warn({ provider: provider.name }, 'Provider exhausted, falling back to next')
                     break
                 }
 
                 // Non-429 error — retry once, then move on
                 if (attempt === 0) {
-                    console.warn(`[LLM] ${provider.name} error: ${err?.message}, retrying once`)
+                    log.warn({ provider: provider.name, err }, 'Provider error, retrying once')
                     await sleep(BACKOFF_DELAYS[0])
                     continue
                 }
 
-                console.error(`[LLM] ${provider.name} failed permanently:`, err?.message)
+                log.error({ provider: provider.name, err }, 'Provider failed permanently')
                 break
             }
         }
     }
 
     // All providers exhausted
-    console.error(`[LLM] All ${tier} providers exhausted`)
+    log.error({ tier }, 'All providers exhausted')
     return { text: '', provider: 'none' }
 }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared logger — single instance used across the entire codebase.
+ *
+ * Dev:  pretty-printed, colorized output via pino-pretty
+ * Prod: structured JSON — pipe to Datadog / CloudWatch / Loki
+ *
+ * Usage:
+ *   import { logger } from '../logger.js'
+ *   const log = logger.child({ module: 'sentinel' })
+ *   log.info({ userId }, 'cycle started')
+ *   log.warn({ latencyMs }, 'bedrock slow — falling back')
+ *   log.error({ err }, 'fatal error')
+ */
+
+import pino from 'pino'
+
+const isDev = process.env.NODE_ENV !== 'production'
+
+export const logger = pino({
+    level: process.env.LOG_LEVEL ?? (isDev ? 'debug' : 'info'),
+    ...(isDev && {
+        transport: {
+            target: 'pino-pretty',
+            options: {
+                colorize: true,
+                translateTime: 'HH:MM:ss',
+                ignore: 'pid,hostname',
+            },
+        },
+    }),
+})

--- a/src/media/tool-media-context.ts
+++ b/src/media/tool-media-context.ts
@@ -107,7 +107,7 @@ export function extractToolMediaContext(toolName: string, rawData: unknown): Too
     ) {
         if (Array.isArray(rootArray)) {
             for (const entry of rootArray.slice(0, 8)) {
-                extractFromFoodEntry(entry, placeNames, itemNames, []) // Do not capture photos
+                extractFromFoodEntry(entry, placeNames, itemNames, photoUrls)
             }
         }
     } else if (

--- a/src/providers/alpha-benchmark.ts
+++ b/src/providers/alpha-benchmark.ts
@@ -1,0 +1,299 @@
+/**
+ * Alpha Provider Benchmark (#140)
+ *
+ * Measures latency, throughput, and function calling accuracy across providers:
+ *   Together AI → Fireworks AI → Groq (tierManager fallback)
+ *
+ * Run:
+ *   TOGETHER_API_KEY=... FIREWORKS_API_KEY=... GROQ_API_KEY=... \
+ *   npx tsx src/providers/alpha-benchmark.ts
+ *
+ * Optional env:
+ *   BENCHMARK_ROUNDS=5        (default: 3 rounds per test)
+ *   BENCHMARK_PROVIDERS=together,fireworks,groq  (default: all configured)
+ */
+
+import { TogetherProvider } from '../llm/providers/together.js'
+import { FireworksProvider } from '../llm/providers/fireworks.js'
+import { generateResponse } from '../llm/tierManager.js'
+import type { LLMProviderWithTools } from '../llm/providers/types.js'
+import { ALPHA_TOOL_DEFINITIONS } from '../tool-definitions.js'
+
+// ─── Config ──────────────────────────────────────────────────────────────────
+
+const ROUNDS = parseInt(process.env.BENCHMARK_ROUNDS ?? '3', 10)
+const SELECTED = new Set((process.env.BENCHMARK_PROVIDERS ?? 'together,fireworks,groq').split(',').map(s => s.trim()))
+
+// ─── Test Cases ───────────────────────────────────────────────────────────────
+
+interface BenchCase {
+    label: string
+    type: 'plain_chat' | 'tool_call'
+    /** Expected tool name when type === 'tool_call', or null */
+    expectedTool: string | null
+    systemPrompt: string
+    userMessage: string
+}
+
+const CASES: BenchCase[] = [
+    {
+        label: 'Plain chat — short greeting',
+        type: 'plain_chat',
+        expectedTool: null,
+        systemPrompt: 'You are Aria, a friendly assistant. Respond in 1-2 sentences.',
+        userMessage: 'Hey! How are you doing today?',
+    },
+    {
+        label: 'Tool call — cab compare',
+        type: 'tool_call',
+        expectedTool: 'cab_compare',
+        systemPrompt: 'You are Aria. Use tools when the user needs real-time data.',
+        userMessage: 'Compare cab prices from Koramangala to Bangalore Airport for me',
+    },
+    {
+        label: 'Tool call — weather check',
+        type: 'tool_call',
+        expectedTool: 'weather_check',
+        systemPrompt: 'You are Aria. Use tools when the user needs real-time data.',
+        userMessage: "What's the weather like in Indiranagar right now?",
+    },
+    {
+        label: 'Tool call — food finder',
+        type: 'tool_call',
+        expectedTool: 'food_finder',
+        systemPrompt: 'You are Aria. Use tools when the user needs real-time data.',
+        userMessage: 'I want to order biryani. What are my options?',
+    },
+    {
+        label: 'Tool call — place search (ambiguous)',
+        type: 'tool_call',
+        expectedTool: 'place_search',
+        systemPrompt: 'You are Aria. Use tools when the user needs real-time data.',
+        userMessage: 'Any good coffee shops open near HSR Layout right now?',
+    },
+    {
+        label: 'Plain chat — no tool needed',
+        type: 'plain_chat',
+        expectedTool: null,
+        systemPrompt: 'You are Aria. Only use tools for real-time data requests.',
+        userMessage: "What's the capital of France?",
+    },
+]
+
+// ─── Result Types ─────────────────────────────────────────────────────────────
+
+interface RoundResult {
+    latencyMs: number
+    toolCalled: string | null
+    correct: boolean
+    error: string | null
+}
+
+interface ProviderReport {
+    providerName: string
+    case: string
+    rounds: RoundResult[]
+    avgLatencyMs: number
+    p95LatencyMs: number
+    accuracy: number   // fraction of rounds where tool call matched expected
+    errorRate: number
+}
+
+// ─── Benchmark Runner ─────────────────────────────────────────────────────────
+
+async function benchmarkProvider(
+    name: string,
+    runner: (c: BenchCase) => Promise<{ latencyMs: number; toolCalled: string | null }>,
+    cases: BenchCase[]
+): Promise<ProviderReport[]> {
+    const reports: ProviderReport[] = []
+
+    for (const c of cases) {
+        const rounds: RoundResult[] = []
+
+        for (let r = 0; r < ROUNDS; r++) {
+            const start = Date.now()
+            try {
+                const { latencyMs, toolCalled } = await runner(c)
+                const correct = c.expectedTool === null
+                    ? toolCalled === null
+                    : toolCalled === c.expectedTool
+                rounds.push({ latencyMs, toolCalled, correct, error: null })
+            } catch (err) {
+                rounds.push({
+                    latencyMs: Date.now() - start,
+                    toolCalled: null,
+                    correct: false,
+                    error: (err as Error).message.slice(0, 100),
+                })
+            }
+
+            // Small delay to avoid rate limiting between rounds
+            if (r < ROUNDS - 1) await sleep(500)
+        }
+
+        const latencies = rounds.filter(r => !r.error).map(r => r.latencyMs).sort((a, b) => a - b)
+        const avgLatencyMs = latencies.length ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length) : 0
+        const p95LatencyMs = latencies.length ? latencies[Math.floor(latencies.length * 0.95)] ?? latencies[latencies.length - 1] : 0
+        const accuracy = rounds.filter(r => r.correct).length / rounds.length
+        const errorRate = rounds.filter(r => r.error).length / rounds.length
+
+        reports.push({ providerName: name, case: c.label, rounds, avgLatencyMs, p95LatencyMs, accuracy, errorRate })
+    }
+
+    return reports
+}
+
+// ─── Provider Runners ─────────────────────────────────────────────────────────
+
+function makeToolRunner(provider: LLMProviderWithTools) {
+    return async (c: BenchCase) => {
+        const start = Date.now()
+
+        if (c.type === 'tool_call') {
+            const result = await provider.chatWithTools({
+                messages: [{ role: 'user', content: c.userMessage }],
+                systemPrompt: c.systemPrompt,
+                tools: ALPHA_TOOL_DEFINITIONS,
+                toolChoice: 'auto',
+                maxTokens: 256,
+                temperature: 0.1,
+            })
+            return {
+                latencyMs: result.latencyMs,
+                toolCalled: result.toolCalls[0]?.function.name ?? null,
+            }
+        } else {
+            const result = await provider.chat({
+                messages: [{ role: 'user', content: c.userMessage }],
+                systemPrompt: c.systemPrompt,
+                maxTokens: 128,
+                temperature: 0.7,
+            })
+            return { latencyMs: result.latencyMs, toolCalled: null }
+        }
+    }
+}
+
+async function groqRunner(c: BenchCase) {
+    const start = Date.now()
+    const messages = [
+        { role: 'system' as const, content: c.systemPrompt },
+        { role: 'user' as const, content: c.userMessage },
+    ]
+    const { text } = await generateResponse(messages, {
+        maxTokens: 128,
+        temperature: 0.7,
+    })
+    return { latencyMs: Date.now() - start, toolCalled: null }
+}
+
+// ─── Report Printer ───────────────────────────────────────────────────────────
+
+function printReport(all: ProviderReport[]): void {
+    console.log('\n' + '═'.repeat(80))
+    console.log('  ALPHA PROVIDER BENCHMARK RESULTS')
+    console.log('═'.repeat(80))
+
+    const byProvider = new Map<string, ProviderReport[]>()
+    for (const r of all) {
+        const list = byProvider.get(r.providerName) ?? []
+        list.push(r)
+        byProvider.set(r.providerName, list)
+    }
+
+    for (const [providerName, reports] of byProvider) {
+        console.log(`\n▶ ${providerName.toUpperCase()}`)
+        console.log('─'.repeat(60))
+
+        let totalAccuracy = 0
+        let totalAvgLatency = 0
+        let totalErrors = 0
+
+        for (const r of reports) {
+            const toolAccuracy = CASES.find(c => c.label === r.case)?.expectedTool !== null
+                ? ` accuracy=${(r.accuracy * 100).toFixed(0)}%`
+                : ''
+            console.log(
+                `  ${r.case.padEnd(45)} avg=${r.avgLatencyMs}ms  p95=${r.p95LatencyMs}ms${toolAccuracy}${r.errorRate > 0 ? `  errors=${(r.errorRate * 100).toFixed(0)}%` : ''}`
+            )
+            totalAccuracy += r.accuracy
+            totalAvgLatency += r.avgLatencyMs
+            totalErrors += r.errorRate
+        }
+
+        const n = reports.length
+        console.log('─'.repeat(60))
+        console.log(`  TOTALS  avg_latency=${Math.round(totalAvgLatency / n)}ms  avg_accuracy=${(totalAccuracy / n * 100).toFixed(0)}%  avg_errors=${(totalErrors / n * 100).toFixed(0)}%`)
+    }
+
+    // Side-by-side comparison for tool_call cases
+    const toolCases = CASES.filter(c => c.type === 'tool_call').map(c => c.label)
+    if (toolCases.length > 0 && all.length > 0) {
+        console.log('\n' + '─'.repeat(80))
+        console.log('  FUNCTION CALLING ACCURACY COMPARISON')
+        console.log('─'.repeat(80))
+        const providers = [...new Set(all.map(r => r.providerName))]
+        const header = 'Test Case'.padEnd(47) + providers.map(p => p.padEnd(14)).join('')
+        console.log(header)
+        for (const label of toolCases) {
+            const row = label.padEnd(47) + providers.map(p => {
+                const report = all.find(r => r.providerName === p && r.case === label)
+                if (!report) return 'N/A'.padEnd(14)
+                return `${(report.accuracy * 100).toFixed(0)}% (${report.avgLatencyMs}ms)`.padEnd(14)
+            }).join('')
+            console.log(row)
+        }
+    }
+
+    console.log('\n' + '═'.repeat(80) + '\n')
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+    console.log(`\nAlpha Provider Benchmark — ${ROUNDS} rounds per case`)
+    console.log(`Providers: ${[...SELECTED].join(', ')}`)
+    console.log(`Cases: ${CASES.length} (${CASES.filter(c => c.type === 'tool_call').length} tool calls, ${CASES.filter(c => c.type === 'plain_chat').length} plain chat)\n`)
+
+    const allReports: ProviderReport[] = []
+    const together = new TogetherProvider()
+    const fireworks = new FireworksProvider()
+
+    if (SELECTED.has('together') && await together.isAvailable()) {
+        console.log('Benchmarking Together AI...')
+        const reports = await benchmarkProvider('together', makeToolRunner(together), CASES)
+        allReports.push(...reports)
+    } else if (SELECTED.has('together')) {
+        console.warn('⚠️  Together AI: TOGETHER_API_KEY not set — skipping')
+    }
+
+    if (SELECTED.has('fireworks') && await fireworks.isAvailable()) {
+        console.log('Benchmarking Fireworks AI...')
+        const reports = await benchmarkProvider('fireworks', makeToolRunner(fireworks), CASES)
+        allReports.push(...reports)
+    } else if (SELECTED.has('fireworks')) {
+        console.warn('⚠️  Fireworks AI: FIREWORKS_API_KEY not set — skipping')
+    }
+
+    if (SELECTED.has('groq') && process.env.GROQ_API_KEY) {
+        console.log('Benchmarking Groq (plain chat only — no function calling in tierManager)...')
+        // Groq via tierManager doesn't support function calling, only plain chat cases
+        const groqCases = CASES.filter(c => c.type === 'plain_chat')
+        const reports = await benchmarkProvider('groq', groqRunner, groqCases)
+        allReports.push(...reports)
+    } else if (SELECTED.has('groq')) {
+        console.warn('⚠️  Groq: GROQ_API_KEY not set — skipping')
+    }
+
+    if (allReports.length === 0) {
+        console.error('No providers were benchmarked. Set at least one API key.')
+        process.exit(1)
+    }
+
+    printReport(allReports)
+}
+
+function sleep(ms: number) { return new Promise(r => setTimeout(r, ms)) }
+
+main().catch(err => { console.error('Benchmark failed:', err); process.exit(1) })

--- a/src/providers/alpha-benchmark.ts
+++ b/src/providers/alpha-benchmark.ts
@@ -217,6 +217,9 @@ function printReport(all: ProviderReport[]): void {
             console.log(
                 `  ${r.case.padEnd(45)} avg=${r.avgLatencyMs}ms  p95=${r.p95LatencyMs}ms${toolAccuracy}${r.errorRate > 0 ? `  errors=${(r.errorRate * 100).toFixed(0)}%` : ''}`
             )
+            // Surface the first error message so failures are diagnosable
+            const firstErr = r.rounds.find(rd => rd.error)?.error
+            if (firstErr) console.log(`    ↳ ${firstErr}`)
             totalAccuracy += r.accuracy
             totalAvgLatency += r.avgLatencyMs
             totalErrors += r.errorRate

--- a/src/providers/alpha-provider.ts
+++ b/src/providers/alpha-provider.ts
@@ -1,0 +1,139 @@
+/**
+ * Alpha Provider — High-level abstraction for the user-facing 70B model.
+ *
+ * Failover chain: Together AI → Fireworks AI → Groq (via tierManager)
+ *
+ * Together is preferred for its function calling accuracy and 600 rpm ceiling.
+ * Fireworks is the second tier. Groq (existing tierManager) is the safety net.
+ *
+ * Usage:
+ *   const alpha = new AlphaProvider()
+ *   const result = await alpha.chatWithTools({ messages, tools, systemPrompt })
+ *   // or for plain chat:
+ *   const result = await alpha.chat({ messages, systemPrompt })
+ */
+
+import { logger as rootLogger } from '../logger.js'
+import { TogetherProvider } from '../llm/providers/together.js'
+import { FireworksProvider } from '../llm/providers/fireworks.js'
+import { generateResponse, type ChatMessage, type CallOptions } from '../llm/tierManager.js'
+import type {
+    LLMProviderWithTools,
+    ChatParams,
+    ChatResponse,
+    ToolChatParams,
+    ToolChatResponse,
+} from '../llm/providers/types.js'
+
+const log = rootLogger.child({ module: 'alpha-provider' })
+
+// ─── AlphaProvider ───────────────────────────────────────────────────────────
+
+export class AlphaProvider {
+    private readonly together: LLMProviderWithTools
+    private readonly fireworks: LLMProviderWithTools
+
+    constructor() {
+        this.together = new TogetherProvider()
+        this.fireworks = new FireworksProvider()
+    }
+
+    /**
+     * Chat with function calling support.
+     * Tries Together → Fireworks → throws (caller falls back to Groq plain chat).
+     */
+    async chatWithTools(params: ToolChatParams): Promise<ToolChatResponse> {
+        // Together first
+        if (await this.together.isAvailable()) {
+            const start = Date.now()
+            try {
+                const result = await this.together.chatWithTools(params)
+                log.info({ provider: 'together', latencyMs: Date.now() - start }, 'alpha call')
+                return result
+            } catch (err) {
+                log.warn({ provider: 'together', err }, 'together failed — trying fireworks')
+            }
+        }
+
+        // Fireworks fallback
+        if (await this.fireworks.isAvailable()) {
+            const start = Date.now()
+            try {
+                const result = await this.fireworks.chatWithTools(params)
+                log.info({ provider: 'fireworks', latencyMs: Date.now() - start }, 'alpha call')
+                return result
+            } catch (err) {
+                log.warn({ provider: 'fireworks', err }, 'fireworks failed')
+            }
+        }
+
+        throw new Error('[AlphaProvider] No provider available for chatWithTools — Together and Fireworks both failed or unconfigured')
+    }
+
+    /**
+     * Plain chat (no tools). Tries Together → Fireworks → Groq (tierManager).
+     */
+    async chat(params: ChatParams): Promise<ChatResponse> {
+        // Together first
+        if (await this.together.isAvailable()) {
+            const start = Date.now()
+            try {
+                const result = await this.together.chat(params)
+                log.info({ provider: 'together', latencyMs: Date.now() - start }, 'alpha call')
+                return result
+            } catch (err) {
+                log.warn({ provider: 'together', err }, 'together failed — trying fireworks')
+            }
+        }
+
+        // Fireworks fallback
+        if (await this.fireworks.isAvailable()) {
+            const start = Date.now()
+            try {
+                const result = await this.fireworks.chat(params)
+                log.info({ provider: 'fireworks', latencyMs: Date.now() - start }, 'alpha call')
+                return result
+            } catch (err) {
+                log.warn({ provider: 'fireworks', err }, 'fireworks failed — falling back to groq')
+            }
+        }
+
+        // Groq fallback via existing tierManager
+        const start = Date.now()
+        const groqMessages = buildGroqMessages(params)
+        const groqOpts = buildGroqOpts(params)
+        const { text, provider } = await generateResponse(groqMessages, groqOpts)
+        log.info({ provider, latencyMs: Date.now() - start }, 'alpha call')
+
+        return {
+            content: text,
+            usage: { inputTokens: 0, outputTokens: 0 },
+            latencyMs: Date.now() - start,
+        }
+    }
+}
+
+// ─── Groq Adapter Helpers ────────────────────────────────────────────────────
+
+function buildGroqMessages(params: ChatParams): ChatMessage[] {
+    const messages: ChatMessage[] = []
+
+    if (params.systemPrompt) {
+        messages.push({ role: 'system', content: params.systemPrompt })
+    }
+
+    for (const msg of params.messages) {
+        if (msg.role === 'tool') continue // Groq tierManager doesn't handle tool results
+        messages.push({ role: msg.role as ChatMessage['role'], content: msg.content })
+    }
+
+    return messages
+}
+
+function buildGroqOpts(params: ChatParams): CallOptions {
+    return {
+        maxTokens: params.maxTokens,
+        temperature: params.temperature,
+        jsonMode: params.jsonMode,
+    }
+}

--- a/src/pulse/engagement-metrics.ts
+++ b/src/pulse/engagement-metrics.ts
@@ -22,6 +22,9 @@ import type {
     WeightedMetric,
 } from './engagement-types.js'
 import type { EngagementState } from './types.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'engagement-metrics' })
 
 // ─── Weight Helpers ──────────────────────────────────────────────────────────
 
@@ -72,7 +75,7 @@ async function loadFromPostgres(userId: string): Promise<EngagementMetricsRecord
             createdAt: row.created_at?.toISOString() ?? new Date().toISOString(),
         }
     } catch (err) {
-        console.error('[EngagementMetrics] PostgreSQL load failed:', err)
+        log.error({ err }, 'PostgreSQL load failed')
         return null
     }
 }
@@ -98,7 +101,7 @@ async function saveToPostgres(record: EngagementMetricsRecord): Promise<void> {
             ],
         )
     } catch (err) {
-        console.error('[EngagementMetrics] PostgreSQL save failed:', err)
+        log.error({ err }, 'PostgreSQL save failed')
     }
 }
 
@@ -143,12 +146,10 @@ export async function initializeMetrics(
     await saveToPostgres(record)
     // DynamoDB is fire-and-forget — don't await in critical path
     putMetricsToDynamo(record).catch(err =>
-        console.error('[EngagementMetrics] DynamoDB init write failed:', err),
+        log.error({ err }, 'DynamoDB init write failed'),
     )
 
-    console.log(
-        `[EngagementMetrics] Initialized for user=${userId} categories=${Object.keys(metrics).join(',')}`,
-    )
+    log.info({ userId, categories: Object.keys(metrics) }, 'Metrics initialized')
 
     return record
 }
@@ -198,7 +199,7 @@ export async function updateMetric(input: MetricUpdateInput): Promise<WeightedMe
 
     // DynamoDB — fire-and-forget single-field update
     updateSingleMetricInDynamo(userId, category, updated, input.isFriendInteraction ?? false).catch(err =>
-        console.error(`[EngagementMetrics] DynamoDB update failed for ${category}:`, err),
+        log.error({ category, err }, 'DynamoDB update failed'),
     )
 
     // CloudWatch metric — fire-and-forget
@@ -262,7 +263,7 @@ export async function syncEngagementState(
         // Bootstrap a minimal record so the state sync is never a no-op.
         // Preference weights will be populated next time initializeMetrics or
         // updateMetric runs; this ensures at least the state/score are persisted.
-        console.log(`[EngagementMetrics] No record found for user=${userId} during syncEngagementState — bootstrapping`)
+        log.info({ userId }, 'No metrics record found during syncEngagementState — bootstrapping')
         record = {
             userId,
             metrics: {},
@@ -281,7 +282,7 @@ export async function syncEngagementState(
 
     await saveToPostgres(record)
     putMetricsToDynamo(record).catch(err =>
-        console.error('[EngagementMetrics] DynamoDB state sync failed:', err),
+        log.error({ err }, 'DynamoDB state sync failed'),
     )
 }
 

--- a/src/pulse/pulse-service.ts
+++ b/src/pulse/pulse-service.ts
@@ -4,6 +4,9 @@ import { syncEngagementState } from './engagement-metrics.js'
 import { extractEngagementSignals } from './signal-extractor.js'
 import { applyDecay, clampScore, isStale, transitionState } from './state-machine.js'
 import type { EngagementState, PulseInput, PulseRecord, PulseSignalHistoryEntry } from './types.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'pulse-service' })
 
 interface PulseDbRow {
   user_id: string
@@ -101,18 +104,21 @@ export class PulseService {
     // Fire-and-forget via setImmediate — never block the scoring path with memory writes
     setImmediate(() => {
       syncEngagementState(input.userId, nextState, nextScore).catch(err =>
-        console.error(`[Pulse] Failed to sync engagement state for ${input.userId}:`, err),
+        log.error({ userId: input.userId, err }, 'Failed to sync engagement state'),
       )
     })
 
     if (current.state !== nextState) {
-      console.log(
-        `[Pulse] State transition user=${input.userId} ${current.state}->${nextState} score=${nextScore} delta=${signals.scoreDelta} signals=${signals.matchedSignals.join(',') || 'none'}`
-      )
+      log.info({
+        userId: input.userId,
+        from: current.state,
+        to: nextState,
+        score: nextScore,
+        delta: signals.scoreDelta,
+        signals: signals.matchedSignals.join(',') || 'none',
+      }, 'State transition')
     } else {
-      console.log(
-        `[Pulse] user=${input.userId} state=${nextState} score=${nextScore} delta=${signals.scoreDelta}`
-      )
+      log.info({ userId: input.userId, state: nextState, score: nextScore, delta: signals.scoreDelta }, 'Pulse update')
     }
 
     return next

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -13,6 +13,9 @@
 
 // @ts-ignore - node-cron has no types
 import cron from 'node-cron'
+import { logger } from './logger.js'
+
+const log = logger.child({ module: 'scheduler' })
 import { runProactiveForAllUsers, runTopicFollowUpsForAllUsers, loadUsersFromDB } from './media/proactiveRunner.js'
 import { registerMediaCron } from './cron/media-cron.js'
 import { runMigrations, cleanupExpiredRateLimits } from './character/session-store.js'
@@ -30,28 +33,28 @@ import { sweepStaleTopics } from './topic-intent/sweep.js'
 export function initScheduler(_databaseUrl: string) {
   // ── 1. Health heartbeat — every 30 seconds ──────────────────────────────
   setInterval(() => {
-    console.log(`[HEARTBEAT] alive — ${new Date().toISOString()}`)
+    log.info('Heartbeat')
   }, 30_000)
 
   // ── 2a. Topic follow-ups — every 30 minutes (Mode A, priority) ─────────
   //    Checks warm topics (confidence > 25%, inactive 4h+) and sends natural follow-ups.
   cron.schedule('*/30 * * * *', async () => {
-    console.log(`[SCHEDULER] Topic follow-up run — ${new Date().toISOString()}`)
+    log.info('Topic follow-up run')
     try {
       await runTopicFollowUpsForAllUsers()
     } catch (err) {
-      console.error('[SCHEDULER] Topic follow-up error:', err)
+      log.error({ err }, 'Topic follow-up error')
     }
   })
 
   // ── 2b. Content blast pipeline — every 2 hours (Mode B, fallback) ───────
   //    Generic content blast when no warm topics exist. Gate checks in runner.
   cron.schedule('0 */2 * * *', async () => {
-    console.log(`[SCHEDULER] Content blast pipeline triggered — ${new Date().toISOString()}`)
+    log.info('Content blast pipeline triggered')
     try {
       await runProactiveForAllUsers()
     } catch (err) {
-      console.error('[SCHEDULER] Content blast pipeline error:', err)
+      log.error({ err }, 'Content blast pipeline error')
     }
   })
 
@@ -63,7 +66,7 @@ export function initScheduler(_databaseUrl: string) {
     try {
       await runSocialOutbound()
     } catch (err) {
-      console.error('[SCHEDULER] Social outbound error:', err)
+      log.error({ err }, 'Social outbound error')
     }
   })
 
@@ -71,9 +74,9 @@ export function initScheduler(_databaseUrl: string) {
   cron.schedule('0 * * * *', async () => {
     try {
       const deleted = await cleanupExpiredRateLimits()
-      if (deleted > 0) console.log(`[SCHEDULER] Cleaned ${deleted} stale rate_limit rows`)
+      if (deleted > 0) log.info({ deleted }, 'Cleaned stale rate_limit rows')
     } catch (err) {
-      console.error('[SCHEDULER] Rate limit cleanup error:', err)
+      log.error({ err }, 'Rate limit cleanup error')
     }
   })
 
@@ -83,7 +86,7 @@ export function initScheduler(_databaseUrl: string) {
     try {
       await sweepStaleTopics()
     } catch (err) {
-      console.error('[SCHEDULER] Stale topic sweep error:', err)
+      log.error({ err }, 'Stale topic sweep error')
     }
   })
 
@@ -92,12 +95,10 @@ export function initScheduler(_databaseUrl: string) {
     try {
       const summary = await checkPriceAlerts()
       if (!summary.skipped && (summary.checked > 0 || summary.triggered > 0 || summary.errors > 0)) {
-        console.log(
-          `[SCHEDULER] Price alerts checked=${summary.checked} triggered=${summary.triggered} errors=${summary.errors}`,
-        )
+        log.info({ checked: summary.checked, triggered: summary.triggered, errors: summary.errors }, 'Price alerts checked')
       }
     } catch (err) {
-      console.error('[SCHEDULER] Price alert check error:', err)
+      log.error({ err }, 'Price alert check error')
     }
   })
 
@@ -107,7 +108,7 @@ export function initScheduler(_databaseUrl: string) {
     try {
       await refreshAllStimuliForActiveLocations()
     } catch (err) {
-      console.error('[SCHEDULER] Stimulus batch refresh error:', err)
+      log.error({ err }, 'Stimulus batch refresh error')
     }
   })
 
@@ -116,7 +117,7 @@ export function initScheduler(_databaseUrl: string) {
     try {
       await runIntelligenceCron(3)
     } catch (err) {
-      console.error('[SCHEDULER] Intelligence cron error:', err)
+      log.error({ err }, 'Intelligence cron error')
     }
   })
 
@@ -125,7 +126,7 @@ export function initScheduler(_databaseUrl: string) {
     try {
       await runFriendBridgeOutbound()
     } catch (err) {
-      console.error('[SCHEDULER] Friend bridge outbound error:', err)
+      log.error({ err }, 'Friend bridge outbound error')
     }
   })
 
@@ -134,7 +135,7 @@ export function initScheduler(_databaseUrl: string) {
     try {
       await processMemoryWriteQueue(20)
     } catch (err) {
-      console.error('[SCHEDULER] Memory queue worker failed:', err)
+      log.error({ err }, 'Memory queue worker failed')
     }
   })
 
@@ -143,7 +144,7 @@ export function initScheduler(_databaseUrl: string) {
     try {
       await checkAndSummarizeSessions()
     } catch (err) {
-      console.error('[SCHEDULER] Session summarization failed:', err)
+      log.error({ err }, 'Session summarization failed')
     }
   })
 
@@ -153,9 +154,9 @@ export function initScheduler(_databaseUrl: string) {
       await runMigrations()
       await loadUsersFromDB()
     } catch (err) {
-      console.error('[SCHEDULER] Startup DB tasks failed:', err)
+      log.error({ err }, 'Startup DB tasks failed')
     }
   }, 8000) // after DB pool is ready
 
-  console.log('[SCHEDULER] Initialized — heartbeat (30s) + topic-followups (*/30m) + content-blast (*/2h) + media (*/6h) + price alerts (*/30) + weather (*/30) + traffic (*/30) + festival (*/6h) + intelligence (*/2h) + friend-bridge (*/30m) + memory queue (*/30s) + session summaries (*/5m)')
+  log.info('Scheduler initialized')
 }

--- a/src/tool-arg-schemas.ts
+++ b/src/tool-arg-schemas.ts
@@ -1,0 +1,96 @@
+/**
+ * Alpha Tool Argument Schemas (#129)
+ *
+ * Zod schemas that mirror the JSON Schema definitions in tool-definitions.ts.
+ * parseToolArgs() is the single safe-parse entry-point used by executeAlphaTool()
+ * before any execution path is reached.
+ *
+ * Accepts a raw JSON string (as returned in function.arguments by provider APIs)
+ * or an already-parsed object.  Never throws.
+ */
+
+import { z } from 'zod'
+
+// ─── Schemas ───────────────────────────────────────────────────────────────────
+
+const SCHEMAS: Record<string, z.ZodType> = {
+    cab_compare: z.object({
+        pickup:      z.string().min(1),
+        destination: z.string().min(1),
+        passengers:  z.number().int().min(1).optional(),
+    }),
+
+    place_search: z.object({
+        query:     z.string().min(1),
+        location:  z.string().optional(),
+        openNow:   z.boolean().optional(),
+        minRating: z.number().min(1).max(5).optional(),
+    }),
+
+    weather_check: z.object({
+        location: z.string().min(1),
+    }),
+
+    food_finder: z.object({
+        query:    z.string().min(1),
+        location: z.string().min(1),
+    }),
+
+    price_alert: z.object({
+        query:    z.string().min(1),
+        location: z.string().optional(),
+        category: z.enum(['grocery', 'snacks', 'beverages', 'personal_care', 'other']).optional(),
+    }),
+
+    event_lookup: z.object({
+        query:    z.string().min(1),
+        location: z.string().min(1),
+        date:     z.string().optional(),
+    }),
+
+    friend_activity: z.object({
+        friendId: z.string().min(1),
+    }),
+
+    set_reminder: z.object({
+        message: z.string().min(1),
+        time:    z.string().min(1),
+    }),
+}
+
+// ─── Public API ────────────────────────────────────────────────────────────────
+
+export type ParseResult =
+    | { ok: true;  args: Record<string, unknown> }
+    | { ok: false; error: string }
+
+/**
+ * Safely parse and validate raw tool arguments.
+ *
+ * @param toolName  Alpha tool name (e.g. "cab_compare")
+ * @param raw       Raw JSON string from function.arguments, or a plain object
+ */
+export function parseToolArgs(toolName: string, raw: unknown): ParseResult {
+    // 1. JSON-decode if the provider sent a raw string
+    let candidate: unknown = raw
+    if (typeof raw === 'string') {
+        try {
+            candidate = JSON.parse(raw)
+        } catch {
+            return { ok: false, error: `Invalid JSON in function.arguments for "${toolName}"` }
+        }
+    }
+
+    // 2. Validate and coerce through the Zod schema
+    const schema = SCHEMAS[toolName]
+    if (!schema) {
+        return { ok: false, error: `No argument schema registered for "${toolName}"` }
+    }
+
+    const result = schema.safeParse(candidate)
+    if (!result.success) {
+        return { ok: false, error: `Argument validation failed for "${toolName}": ${result.error.message}` }
+    }
+
+    return { ok: true, args: result.data as Record<string, unknown> }
+}

--- a/src/tool-definitions.test.ts
+++ b/src/tool-definitions.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Unit tests for Alpha Tool Definitions (#129)
+ *
+ * Validates that every tool schema is well-formed and passes Groq's function
+ * calling contract: correct structure, required fields present in properties,
+ * valid JSON Schema types, and no duplicate names.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { ALPHA_TOOL_DEFINITIONS, ALPHA_TOOL_NAMES } from './tool-definitions.js'
+
+// ─── Schema Validator ─────────────────────────────────────────────────────────
+
+/**
+ * Validates a single tool definition against Groq's function-calling schema.
+ * Returns an array of error messages (empty = valid).
+ */
+function validateToolSchema(tool: (typeof ALPHA_TOOL_DEFINITIONS)[number]): string[] {
+    const errors: string[] = []
+    const name = tool?.function?.name ?? '(unknown)'
+
+    if (tool.type !== 'function') errors.push(`${name}: type must be "function"`)
+    if (!tool.function) { errors.push(`${name}: missing .function`); return errors }
+
+    if (!tool.function.name) errors.push(`${name}: missing function.name`)
+    if (typeof tool.function.name !== 'string') errors.push(`${name}: function.name must be string`)
+    if (!tool.function.description || tool.function.description.trim().length < 10)
+        errors.push(`${name}: function.description too short or missing`)
+
+    const params = tool.function.parameters
+    if (!params) { errors.push(`${name}: missing function.parameters`); return errors }
+    if (params.type !== 'object') errors.push(`${name}: parameters.type must be "object"`)
+    if (!params.properties || typeof params.properties !== 'object')
+        errors.push(`${name}: parameters.properties must be an object`)
+    if (!Array.isArray(params.required)) errors.push(`${name}: parameters.required must be an array`)
+
+    // Every required field must exist in properties
+    if (Array.isArray(params.required) && params.properties) {
+        for (const req of params.required as string[]) {
+            if (!(req in (params.properties as object))) {
+                errors.push(`${name}: required field "${req}" not found in properties`)
+            }
+        }
+    }
+
+    // Each property must have a valid type
+    const VALID_TYPES = new Set(['string', 'number', 'boolean', 'array', 'object', 'integer'])
+    if (params.properties) {
+        for (const [propName, propDef] of Object.entries(params.properties as Record<string, any>)) {
+            if (!propDef.type) errors.push(`${name}.${propName}: missing type`)
+            else if (!VALID_TYPES.has(propDef.type)) errors.push(`${name}.${propName}: invalid type "${propDef.type}"`)
+            if (!propDef.description) errors.push(`${name}.${propName}: missing description`)
+        }
+    }
+
+    return errors
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ALPHA_TOOL_DEFINITIONS — schema validation', () => {
+    it('exports exactly 8 tool definitions', () => {
+        expect(ALPHA_TOOL_DEFINITIONS).toHaveLength(8)
+    })
+
+    it('has no duplicate tool names', () => {
+        const names = ALPHA_TOOL_DEFINITIONS.map(t => t.function.name)
+        const unique = new Set(names)
+        expect(unique.size).toBe(names.length)
+    })
+
+    it('ALPHA_TOOL_NAMES set matches definition names', () => {
+        const defNames = new Set(ALPHA_TOOL_DEFINITIONS.map(t => t.function.name))
+        expect(ALPHA_TOOL_NAMES).toEqual(defNames)
+    })
+
+    it.each(ALPHA_TOOL_DEFINITIONS)('$function.name passes schema validation', (tool) => {
+        const errors = validateToolSchema(tool)
+        expect(errors).toEqual([])
+    })
+
+    it('contains all 8 expected tool names', () => {
+        const expected = [
+            'cab_compare',
+            'place_search',
+            'weather_check',
+            'food_finder',
+            'price_alert',
+            'event_lookup',
+            'friend_activity',
+            'set_reminder',
+        ]
+        for (const name of expected) {
+            expect(ALPHA_TOOL_NAMES.has(name)).toBe(true)
+        }
+    })
+})
+
+describe('cab_compare', () => {
+    const tool = ALPHA_TOOL_DEFINITIONS.find(t => t.function.name === 'cab_compare')!
+
+    it('has pickup and destination as required', () => {
+        expect(tool.function.parameters.required).toContain('pickup')
+        expect(tool.function.parameters.required).toContain('destination')
+    })
+
+    it('passengers is optional', () => {
+        expect(tool.function.parameters.required).not.toContain('passengers')
+        expect(tool.function.parameters.properties).toHaveProperty('passengers')
+    })
+
+    it('passengers is type number', () => {
+        const props = tool.function.parameters.properties as any
+        expect(props.passengers.type).toBe('number')
+    })
+})
+
+describe('place_search', () => {
+    const tool = ALPHA_TOOL_DEFINITIONS.find(t => t.function.name === 'place_search')!
+
+    it('only query is required', () => {
+        expect(tool.function.parameters.required).toEqual(['query'])
+    })
+
+    it('has openNow as boolean', () => {
+        const props = tool.function.parameters.properties as any
+        expect(props.openNow.type).toBe('boolean')
+    })
+
+    it('has minRating as number', () => {
+        const props = tool.function.parameters.properties as any
+        expect(props.minRating.type).toBe('number')
+    })
+})
+
+describe('weather_check', () => {
+    const tool = ALPHA_TOOL_DEFINITIONS.find(t => t.function.name === 'weather_check')!
+
+    it('requires only location', () => {
+        expect(tool.function.parameters.required).toEqual(['location'])
+    })
+})
+
+describe('food_finder', () => {
+    const tool = ALPHA_TOOL_DEFINITIONS.find(t => t.function.name === 'food_finder')!
+
+    it('requires only query', () => {
+        expect(tool.function.parameters.required).toEqual(['query'])
+    })
+
+    it('location is optional', () => {
+        expect(tool.function.parameters.required).not.toContain('location')
+        expect(tool.function.parameters.properties).toHaveProperty('location')
+    })
+})
+
+describe('price_alert', () => {
+    const tool = ALPHA_TOOL_DEFINITIONS.find(t => t.function.name === 'price_alert')!
+
+    it('requires only query', () => {
+        expect(tool.function.parameters.required).toEqual(['query'])
+    })
+
+    it('has enum on category field', () => {
+        const props = tool.function.parameters.properties as any
+        expect(Array.isArray(props.category.enum)).toBe(true)
+        expect(props.category.enum).toContain('grocery')
+    })
+})
+
+describe('event_lookup', () => {
+    const tool = ALPHA_TOOL_DEFINITIONS.find(t => t.function.name === 'event_lookup')!
+
+    it('requires query and location', () => {
+        expect(tool.function.parameters.required).toContain('query')
+        expect(tool.function.parameters.required).toContain('location')
+    })
+
+    it('date is optional', () => {
+        expect(tool.function.parameters.required).not.toContain('date')
+        expect(tool.function.parameters.properties).toHaveProperty('date')
+    })
+})
+
+describe('set_reminder', () => {
+    const tool = ALPHA_TOOL_DEFINITIONS.find(t => t.function.name === 'set_reminder')!
+
+    it('requires message and time', () => {
+        expect(tool.function.parameters.required).toContain('message')
+        expect(tool.function.parameters.required).toContain('time')
+    })
+})
+
+describe('friend_activity', () => {
+    const tool = ALPHA_TOOL_DEFINITIONS.find(t => t.function.name === 'friend_activity')!
+
+    it('requires friendId', () => {
+        expect(tool.function.parameters.required).toContain('friendId')
+    })
+})

--- a/src/tool-definitions.test.ts
+++ b/src/tool-definitions.test.ts
@@ -144,13 +144,9 @@ describe('weather_check', () => {
 describe('food_finder', () => {
     const tool = ALPHA_TOOL_DEFINITIONS.find(t => t.function.name === 'food_finder')!
 
-    it('requires only query', () => {
-        expect(tool.function.parameters.required).toEqual(['query'])
-    })
-
-    it('location is optional', () => {
-        expect(tool.function.parameters.required).not.toContain('location')
-        expect(tool.function.parameters.properties).toHaveProperty('location')
+    it('requires query and location', () => {
+        expect(tool.function.parameters.required).toContain('query')
+        expect(tool.function.parameters.required).toContain('location')
     })
 })
 

--- a/src/tool-definitions.ts
+++ b/src/tool-definitions.ts
@@ -99,10 +99,10 @@ export const ALPHA_TOOL_DEFINITIONS: ProviderTool[] = [
                     },
                     location: {
                         type: 'string',
-                        description: 'Area to search in. Omit to use user\'s home location.',
+                        description: 'Area to search in (e.g. "Koramangala", "Andheri West"). Required — ask the user if unknown.',
                     },
                 },
-                required: ['query'],
+                required: ['query', 'location'],
             },
         },
     },

--- a/src/tool-definitions.ts
+++ b/src/tool-definitions.ts
@@ -1,0 +1,205 @@
+/**
+ * Alpha Tool Definitions (#129)
+ *
+ * 8 curated Groq/Together-compatible function schemas for Alpha's native
+ * function calling. These are a focused subset of the 21 tools in
+ * src/tools/index.ts, optimised for Alpha's 1-2 call reactive pipeline.
+ *
+ * Alpha tool names are distinct from the legacy tool names so that both
+ * pipelines can coexist during the transition (no accidental cross-wiring).
+ */
+
+import type { ProviderTool } from './llm/providers/types.js'
+
+// ─── Definitions ─────────────────────────────────────────────────────────────
+
+export const ALPHA_TOOL_DEFINITIONS: ProviderTool[] = [
+    {
+        type: 'function',
+        function: {
+            name: 'cab_compare',
+            description: 'Compare cab/ride prices across Ola, Uber, and Rapido for a given pickup and destination. Use when the user wants to know ride options or costs.',
+            parameters: {
+                type: 'object',
+                properties: {
+                    pickup: {
+                        type: 'string',
+                        description: 'Pickup location (area name, landmark, or full address)',
+                    },
+                    destination: {
+                        type: 'string',
+                        description: 'Drop-off destination (area name, landmark, or full address)',
+                    },
+                    passengers: {
+                        type: 'number',
+                        description: 'Number of passengers (default 1)',
+                    },
+                },
+                required: ['pickup', 'destination'],
+            },
+        },
+    },
+    {
+        type: 'function',
+        function: {
+            name: 'place_search',
+            description: 'Search for places, restaurants, cafes, shops, or services near a location. Use when the user asks for recommendations or where to find something.',
+            parameters: {
+                type: 'object',
+                properties: {
+                    query: {
+                        type: 'string',
+                        description: 'What to search for (e.g. "coffee shops", "ATM", "pharmacy near me")',
+                    },
+                    location: {
+                        type: 'string',
+                        description: 'Area or neighbourhood to search in. Omit to use user\'s home location.',
+                    },
+                    openNow: {
+                        type: 'boolean',
+                        description: 'Filter to only currently open places',
+                    },
+                    minRating: {
+                        type: 'number',
+                        description: 'Minimum Google rating (1-5)',
+                    },
+                },
+                required: ['query'],
+            },
+        },
+    },
+    {
+        type: 'function',
+        function: {
+            name: 'weather_check',
+            description: 'Get current weather and forecast for a location. Use when the user asks about weather, whether to carry an umbrella, outdoor plans, etc.',
+            parameters: {
+                type: 'object',
+                properties: {
+                    location: {
+                        type: 'string',
+                        description: 'City or area name (e.g. "Indiranagar, Bangalore")',
+                    },
+                },
+                required: ['location'],
+            },
+        },
+    },
+    {
+        type: 'function',
+        function: {
+            name: 'food_finder',
+            description: 'Compare food prices and delivery options across Swiggy, Zomato, and other platforms for a given dish or restaurant. Use when the user wants to order food or find the best deal.',
+            parameters: {
+                type: 'object',
+                properties: {
+                    query: {
+                        type: 'string',
+                        description: 'What food or restaurant to search for (e.g. "biryani", "McDonald\'s", "healthy salad")',
+                    },
+                    location: {
+                        type: 'string',
+                        description: 'Area to search in. Omit to use user\'s home location.',
+                    },
+                },
+                required: ['query'],
+            },
+        },
+    },
+    {
+        type: 'function',
+        function: {
+            name: 'price_alert',
+            description: 'Compare prices for a product or grocery item across quick-commerce platforms (Blinkit, Zepto, Instamart). Use when the user asks about grocery prices or wants to find the cheapest option.',
+            parameters: {
+                type: 'object',
+                properties: {
+                    query: {
+                        type: 'string',
+                        description: 'Product or item to compare (e.g. "milk 1L", "Lay\'s chips", "paneer 500g")',
+                    },
+                    location: {
+                        type: 'string',
+                        description: 'Area to search in. Omit to use user\'s home location.',
+                    },
+                    category: {
+                        type: 'string',
+                        description: 'Product category hint: "grocery", "snacks", "beverages", "personal_care"',
+                        enum: ['grocery', 'snacks', 'beverages', 'personal_care', 'other'],
+                    },
+                },
+                required: ['query'],
+            },
+        },
+    },
+    {
+        type: 'function',
+        function: {
+            name: 'event_lookup',
+            description: 'Find events, shows, exhibitions, or activities happening in a city or area. Use when the user asks what\'s on, things to do, or plans for the weekend.',
+            parameters: {
+                type: 'object',
+                properties: {
+                    query: {
+                        type: 'string',
+                        description: 'Type of event or activity (e.g. "concerts", "art exhibitions", "standup comedy", "things to do this weekend")',
+                    },
+                    location: {
+                        type: 'string',
+                        description: 'City or area to search (e.g. "Bangalore", "Koramangala")',
+                    },
+                    date: {
+                        type: 'string',
+                        description: 'Date or time range in natural language (e.g. "this weekend", "tomorrow", "next week")',
+                    },
+                },
+                required: ['query', 'location'],
+            },
+        },
+    },
+    {
+        type: 'function',
+        function: {
+            name: 'friend_activity',
+            description: 'Check what a friend is up to or their recent activity. Use when the user asks about a specific friend\'s plans or location.',
+            parameters: {
+                type: 'object',
+                properties: {
+                    friendId: {
+                        type: 'string',
+                        description: 'Friend\'s user ID or name as known to the system',
+                    },
+                },
+                required: ['friendId'],
+            },
+        },
+    },
+    {
+        type: 'function',
+        function: {
+            name: 'set_reminder',
+            description: 'Set a reminder or alarm for the user at a specific time. Use when the user asks to be reminded about something.',
+            parameters: {
+                type: 'object',
+                properties: {
+                    message: {
+                        type: 'string',
+                        description: 'What to remind the user about',
+                    },
+                    time: {
+                        type: 'string',
+                        description: 'When to send the reminder, in natural language (e.g. "in 30 minutes", "at 7pm", "tomorrow morning")',
+                    },
+                },
+                required: ['message', 'time'],
+            },
+        },
+    },
+]
+
+// ─── Name Registry ────────────────────────────────────────────────────────────
+
+/** Fast O(1) lookup: is this tool name a valid Alpha tool? */
+export const ALPHA_TOOL_NAMES: ReadonlySet<string> = new Set(
+    ALPHA_TOOL_DEFINITIONS.map(t => t.function.name)
+)

--- a/src/tool-executor.test.ts
+++ b/src/tool-executor.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for Alpha Tool Executor (#129)
+ *
+ * Verifies correct name mapping (Alpha → legacy), stub returns for Phase 3
+ * tools, event_lookup query injection, and error handling.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { executeAlphaTool } from './tool-executor.js'
+import type { ToolExecutionResult } from './hooks.js'
+
+// ─── Mock bodyHooks ───────────────────────────────────────────────────────────
+
+const mockExecuteTool = vi.fn<[string, Record<string, unknown>], Promise<ToolExecutionResult>>()
+
+vi.mock('./tools/index.js', () => ({
+    bodyHooks: {
+        executeTool: (...args: [string, Record<string, unknown>]) => mockExecuteTool(...args),
+        getAvailableTools: () => [],
+    },
+}))
+
+// Mock logger to silence output during tests
+vi.mock('./logger.js', () => ({
+    logger: {
+        child: () => ({
+            debug: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+        }),
+    },
+}))
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const successResult = (data: unknown): ToolExecutionResult => ({ success: true, data })
+const failResult = (error: string): ToolExecutionResult => ({ success: false, data: null, error })
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('executeAlphaTool — name mapping', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockExecuteTool.mockResolvedValue(successResult({ rides: [] }))
+    })
+
+    it('cab_compare → compare_rides', async () => {
+        await executeAlphaTool('cab_compare', { pickup: 'Koramangala', destination: 'Airport' })
+        expect(mockExecuteTool).toHaveBeenCalledWith('compare_rides', { pickup: 'Koramangala', destination: 'Airport' })
+    })
+
+    it('place_search → search_places', async () => {
+        await executeAlphaTool('place_search', { query: 'coffee', location: 'Indiranagar' })
+        expect(mockExecuteTool).toHaveBeenCalledWith('search_places', { query: 'coffee', location: 'Indiranagar' })
+    })
+
+    it('weather_check → get_weather', async () => {
+        await executeAlphaTool('weather_check', { location: 'Bangalore' })
+        expect(mockExecuteTool).toHaveBeenCalledWith('get_weather', { location: 'Bangalore' })
+    })
+
+    it('food_finder → compare_food_prices', async () => {
+        await executeAlphaTool('food_finder', { query: 'biryani' })
+        expect(mockExecuteTool).toHaveBeenCalledWith('compare_food_prices', { query: 'biryani' })
+    })
+
+    it('price_alert → compare_prices_proactive', async () => {
+        await executeAlphaTool('price_alert', { query: 'milk 1L' })
+        expect(mockExecuteTool).toHaveBeenCalledWith('compare_prices_proactive', { query: 'milk 1L' })
+    })
+})
+
+describe('executeAlphaTool — event_lookup query injection', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockExecuteTool.mockResolvedValue(successResult({ places: [] }))
+    })
+
+    it('routes event_lookup to search_places', async () => {
+        await executeAlphaTool('event_lookup', { query: 'concerts', location: 'Bangalore' })
+        expect(mockExecuteTool).toHaveBeenCalledWith(
+            'search_places',
+            expect.objectContaining({ location: 'Bangalore' })
+        )
+    })
+
+    it('prefixes query with "events:" to bias place search toward events', async () => {
+        await executeAlphaTool('event_lookup', { query: 'standup comedy', location: 'HSR Layout' })
+        const calledArgs = mockExecuteTool.mock.calls[0][1]
+        expect((calledArgs.query as string).startsWith('events:')).toBe(true)
+        expect(calledArgs.query).toContain('standup comedy')
+    })
+
+    it('sets openNow to false (events are date-specific, not open-now)', async () => {
+        await executeAlphaTool('event_lookup', { query: 'art show', location: 'MG Road' })
+        expect(mockExecuteTool.mock.calls[0][1].openNow).toBe(false)
+    })
+})
+
+describe('executeAlphaTool — Phase 3 stubs', () => {
+    beforeEach(() => vi.clearAllMocks())
+
+    it('friend_activity returns stub success without calling bodyHooks', async () => {
+        const result = await executeAlphaTool('friend_activity', { friendId: 'user_123' })
+        expect(result.success).toBe(true)
+        expect(mockExecuteTool).not.toHaveBeenCalled()
+    })
+
+    it('set_reminder returns stub success without calling bodyHooks', async () => {
+        const result = await executeAlphaTool('set_reminder', { message: 'Buy milk', time: 'in 1 hour' })
+        expect(result.success).toBe(true)
+        expect(mockExecuteTool).not.toHaveBeenCalled()
+    })
+
+    it('friend_activity stub data mentions Phase 3 unavailability', async () => {
+        const result = await executeAlphaTool('friend_activity', { friendId: 'user_456' })
+        const data = result.data as { status: string; message: string }
+        expect(data.status).toBe('unavailable')
+    })
+
+    it('set_reminder stub data acknowledges the reminder', async () => {
+        const result = await executeAlphaTool('set_reminder', { message: 'Walk the dog', time: 'tomorrow morning' })
+        const data = result.data as { status: string }
+        expect(data.status).toBe('acknowledged')
+    })
+})
+
+describe('executeAlphaTool — unknown tool name', () => {
+    it('returns failure for phantom tool without calling bodyHooks', async () => {
+        const result = await executeAlphaTool('hack_the_planet', { target: 'all' })
+        expect(result.success).toBe(false)
+        expect(result.error).toContain('Unknown Alpha tool')
+        expect(mockExecuteTool).not.toHaveBeenCalled()
+    })
+})
+
+describe('executeAlphaTool — error handling', () => {
+    it('catches unexpected throws from bodyHooks and returns failure', async () => {
+        mockExecuteTool.mockRejectedValueOnce(new Error('API timeout'))
+        const result = await executeAlphaTool('weather_check', { location: 'Delhi' })
+        expect(result.success).toBe(false)
+        expect(result.error).toContain('weather_check')
+    })
+
+    it('returns bodyHooks failure result as-is', async () => {
+        mockExecuteTool.mockResolvedValueOnce(failResult('Rate limit exceeded'))
+        const result = await executeAlphaTool('place_search', { query: 'gym' })
+        expect(result.success).toBe(false)
+        expect(result.error).toBe('Rate limit exceeded')
+    })
+})

--- a/src/tool-executor.test.ts
+++ b/src/tool-executor.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { executeAlphaTool } from './tool-executor.js'
+import { checkRateLimit } from './character/session-store.js'
 import type { ToolExecutionResult } from './hooks.js'
 
 // ─── Mock bodyHooks ───────────────────────────────────────────────────────────
@@ -32,6 +33,12 @@ vi.mock('./logger.js', () => ({
     },
 }))
 
+// Mock session-store so sandbox rate-limit check and audit log don't hit the DB
+vi.mock('./character/session-store.js', () => ({
+    checkRateLimit: vi.fn().mockResolvedValue(true),
+    getPool: vi.fn().mockReturnValue({ query: vi.fn().mockResolvedValue({}) }),
+}))
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const successResult = (data: unknown): ToolExecutionResult => ({ success: true, data })
@@ -45,9 +52,9 @@ describe('executeAlphaTool — name mapping', () => {
         mockExecuteTool.mockResolvedValue(successResult({ rides: [] }))
     })
 
-    it('cab_compare → compare_rides', async () => {
-        await executeAlphaTool('cab_compare', { pickup: 'Koramangala', destination: 'Airport' })
-        expect(mockExecuteTool).toHaveBeenCalledWith('compare_rides', { pickup: 'Koramangala', destination: 'Airport' })
+    it('cab_compare → compare_rides with pickup translated to origin', async () => {
+        await executeAlphaTool('cab_compare', { pickup: 'Koramangala', destination: 'Airport' }, 'user-1')
+        expect(mockExecuteTool).toHaveBeenCalledWith('compare_rides', { origin: 'Koramangala', destination: 'Airport' })
     })
 
     it('place_search → search_places', async () => {
@@ -61,8 +68,8 @@ describe('executeAlphaTool — name mapping', () => {
     })
 
     it('food_finder → compare_food_prices', async () => {
-        await executeAlphaTool('food_finder', { query: 'biryani' })
-        expect(mockExecuteTool).toHaveBeenCalledWith('compare_food_prices', { query: 'biryani' })
+        await executeAlphaTool('food_finder', { query: 'biryani', location: 'Koramangala' }, 'user-1')
+        expect(mockExecuteTool).toHaveBeenCalledWith('compare_food_prices', { query: 'biryani', location: 'Koramangala' })
     })
 
     it('price_alert → compare_prices_proactive', async () => {
@@ -148,5 +155,224 @@ describe('executeAlphaTool — error handling', () => {
         const result = await executeAlphaTool('place_search', { query: 'gym' })
         expect(result.success).toBe(false)
         expect(result.error).toBe('Rate limit exceeded')
+    })
+})
+
+// ─── Negative-path integration: 50 known-bad calls ───────────────────────────
+//
+// Every case in this suite must satisfy two invariants:
+//   1. result.success === false
+//   2. mockExecuteTool is never called  (blocked before reaching the tool)
+//
+// Groups (total = 50):
+//   A. Unknown/phantom tool names            5
+//   B. Malformed JSON rawArgs                8
+//   C. Non-object, non-string rawArgs        6
+//   D. cab_compare bad args                  6
+//   E. weather_check bad args                3
+//   F. food_finder bad args                  4
+//   G. place_search bad args                 4
+//   H. price_alert bad args                  3
+//   I. event_lookup bad args                 4
+//   J. friend_activity bad args              2
+//   K. set_reminder bad args                 2
+//   L. JSON strings that fail schema         2
+//   M. Sandbox rate-limit block              1
+
+describe('negative-path integration — 50 known-bad calls blocked from execution', () => {
+    // Helper: assert both invariants in one call
+    function expectBlocked(result: ToolExecutionResult) {
+        expect(result.success).toBe(false)
+        expect(mockExecuteTool).not.toHaveBeenCalled()
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        // Rate limit passes by default for all tests except group M
+        vi.mocked(checkRateLimit).mockResolvedValue(true)
+    })
+
+    // ── A: Unknown / phantom tool names (5) ──────────────────────────────────
+
+    it.each([
+        ['', { query: 'x' }],
+        ['hack_the_planet', { target: 'all' }],
+        ['compare_rides', { origin: 'A', destination: 'B' }],   // legacy name, not Alpha
+        ['__proto__', {}],
+        ["'; DROP TABLE users; --", {}],
+    ] as [string, Record<string, unknown>][])(
+        'A: unknown tool name "%s" is blocked',
+        async (name, args) => {
+            expectBlocked(await executeAlphaTool(name, args, 'user-1'))
+        },
+    )
+
+    // ── B: Malformed JSON rawArgs — string that cannot be parsed (8) ─────────
+
+    it.each([
+        ['cab_compare', '{bad json'],
+        ['cab_compare', '{pickup: "A", destination: "B"}'],    // unquoted keys
+        ['cab_compare', '{"pickup": "A",}'],                   // trailing comma
+        ['cab_compare', '"just a string"'],                    // JSON string scalar
+        ['cab_compare', '[{"pickup":"A"}]'],                   // JSON array, not object
+        ['weather_check', 'null'],
+        ['weather_check', '42'],
+        ['weather_check', 'true'],
+    ] as [string, string][])(
+        'B: malformed JSON rawArgs for %s → "%s" is blocked',
+        async (name, raw) => {
+            expectBlocked(await executeAlphaTool(name, raw, 'user-1'))
+        },
+    )
+
+    // ── C: Non-string, non-object rawArgs (6) ────────────────────────────────
+
+    it('C1: null rawArgs is blocked', async () => {
+        expectBlocked(await executeAlphaTool('weather_check', null, 'user-1'))
+    })
+    it('C2: undefined rawArgs is blocked', async () => {
+        expectBlocked(await executeAlphaTool('weather_check', undefined, 'user-1'))
+    })
+    it('C3: number rawArgs is blocked', async () => {
+        expectBlocked(await executeAlphaTool('weather_check', 42, 'user-1'))
+    })
+    it('C4: boolean rawArgs is blocked', async () => {
+        expectBlocked(await executeAlphaTool('weather_check', true, 'user-1'))
+    })
+    it('C5: array rawArgs is blocked', async () => {
+        expectBlocked(await executeAlphaTool('weather_check', [], 'user-1'))
+    })
+    it('C6: array-of-objects rawArgs is blocked', async () => {
+        expectBlocked(await executeAlphaTool('cab_compare', [{ pickup: 'A', destination: 'B' }], 'user-1'))
+    })
+
+    // ── D: cab_compare bad args (6) ──────────────────────────────────────────
+
+    it.each([
+        [{ destination: 'Airport' }],                                      // missing pickup
+        [{ pickup: 'Koramangala' }],                                       // missing destination
+        [{}],                                                              // both missing
+        [{ pickup: 123, destination: 'Airport' }],                         // pickup wrong type
+        [{ pickup: '', destination: 'Airport' }],                          // pickup empty string
+        [{ pickup: 'A', destination: 'B', passengers: 0 }],               // passengers below min(1)
+    ] as [Record<string, unknown>][])(
+        'D: cab_compare bad args %j is blocked',
+        async (args) => {
+            expectBlocked(await executeAlphaTool('cab_compare', args, 'user-1'))
+        },
+    )
+
+    // ── E: weather_check bad args (3) ────────────────────────────────────────
+
+    it.each([
+        [{}],                          // missing location
+        [{ location: '' }],            // empty string
+        [{ location: null }],          // null instead of string
+    ] as [Record<string, unknown>][])(
+        'E: weather_check bad args %j is blocked',
+        async (args) => {
+            expectBlocked(await executeAlphaTool('weather_check', args, 'user-1'))
+        },
+    )
+
+    // ── F: food_finder bad args (4) ──────────────────────────────────────────
+
+    it.each([
+        [{ location: 'Bangalore' }],                   // missing query (required)
+        [{ query: 'biryani' }],                        // missing location (now required)
+        [{}],                                          // both missing
+        [{ query: '', location: 'Bangalore' }],        // empty query
+    ] as [Record<string, unknown>][])(
+        'F: food_finder bad args %j is blocked',
+        async (args) => {
+            expectBlocked(await executeAlphaTool('food_finder', args, 'user-1'))
+        },
+    )
+
+    // ── G: place_search bad args (4) ─────────────────────────────────────────
+
+    it.each([
+        [{}],                                              // missing query
+        [{ query: 'cafe', openNow: 'yes' }],              // openNow is string, not boolean
+        [{ query: 'cafe', minRating: 0 }],                // minRating below min(1)
+        [{ query: 'cafe', minRating: 6 }],                // minRating above max(5)
+    ] as [Record<string, unknown>][])(
+        'G: place_search bad args %j is blocked',
+        async (args) => {
+            expectBlocked(await executeAlphaTool('place_search', args, 'user-1'))
+        },
+    )
+
+    // ── H: price_alert bad args (3) ──────────────────────────────────────────
+
+    it.each([
+        [{}],                                                       // missing query
+        [{ query: 'milk', category: 'electronics' }],              // category not in enum
+        [{ query: 'milk', category: 123 }],                        // category wrong type
+    ] as [Record<string, unknown>][])(
+        'H: price_alert bad args %j is blocked',
+        async (args) => {
+            expectBlocked(await executeAlphaTool('price_alert', args, 'user-1'))
+        },
+    )
+
+    // ── I: event_lookup bad args (4) ─────────────────────────────────────────
+
+    it.each([
+        [{ location: 'Bangalore' }],                    // missing query
+        [{ query: 'concerts' }],                        // missing location (required)
+        [{}],                                           // both missing
+        [{ query: '', location: 'Bangalore' }],         // empty query
+    ] as [Record<string, unknown>][])(
+        'I: event_lookup bad args %j is blocked',
+        async (args) => {
+            expectBlocked(await executeAlphaTool('event_lookup', args, 'user-1'))
+        },
+    )
+
+    // ── J: friend_activity bad args (2) ──────────────────────────────────────
+
+    it.each([
+        [{}],                   // missing friendId
+        [{ friendId: '' }],     // empty friendId
+    ] as [Record<string, unknown>][])(
+        'J: friend_activity bad args %j is blocked',
+        async (args) => {
+            expectBlocked(await executeAlphaTool('friend_activity', args, 'user-1'))
+        },
+    )
+
+    // ── K: set_reminder bad args (2) ─────────────────────────────────────────
+
+    it.each([
+        [{ time: 'in 30 minutes' }],       // missing message
+        [{ message: 'Buy milk' }],         // missing time
+    ] as [Record<string, unknown>][])(
+        'K: set_reminder bad args %j is blocked',
+        async (args) => {
+            expectBlocked(await executeAlphaTool('set_reminder', args, 'user-1'))
+        },
+    )
+
+    // ── L: JSON strings that decode to the wrong schema (2) ─────────────────
+
+    it('L1: JSON string with wrong field type for cab_compare is blocked', async () => {
+        // pickup is a number — valid JSON, invalid schema
+        expectBlocked(await executeAlphaTool('cab_compare', '{"pickup": 99, "destination": "Airport"}', 'user-1'))
+    })
+
+    it('L2: JSON string missing required field for food_finder is blocked', async () => {
+        // location is now required; omitting it must fail even when JSON is valid
+        expectBlocked(await executeAlphaTool('food_finder', '{"query": "pizza"}', 'user-1'))
+    })
+
+    // ── M: Sandbox rate-limit block (1) ──────────────────────────────────────
+
+    it('M: rate-limit exceeded blocks execution before bodyHooks is called', async () => {
+        vi.mocked(checkRateLimit).mockResolvedValueOnce(false)
+        const result = await executeAlphaTool('weather_check', { location: 'Delhi' }, 'user-1')
+        expect(result.success).toBe(false)
+        expect(result.error).toContain('Rate limit')
+        expect(mockExecuteTool).not.toHaveBeenCalled()
     })
 })

--- a/src/tool-executor.test.ts
+++ b/src/tool-executor.test.ts
@@ -143,16 +143,25 @@ describe('executeAlphaTool — unknown tool name', () => {
 })
 
 describe('executeAlphaTool — error handling', () => {
+    beforeEach(() => {
+        // vi.clearAllMocks() does not reset mock implementations — only calls/results.
+        // vi.resetAllMocks() is required here to clear the default mockResolvedValue
+        // set by event_lookup's beforeEach, which would otherwise make retry attempts succeed.
+        vi.resetAllMocks()
+        vi.mocked(checkRateLimit).mockResolvedValue(true)
+    })
+
     it('catches unexpected throws from bodyHooks and returns failure', async () => {
         mockExecuteTool.mockRejectedValueOnce(new Error('API timeout'))
-        const result = await executeAlphaTool('weather_check', { location: 'Delhi' })
+        // maxRetries: 0 — single attempt, avoids 500 ms sleep and a spurious retry
+        const result = await executeAlphaTool('weather_check', { location: 'Delhi' }, 'user-1', { maxRetries: 0 })
         expect(result.success).toBe(false)
         expect(result.error).toContain('weather_check')
     })
 
     it('returns bodyHooks failure result as-is', async () => {
         mockExecuteTool.mockResolvedValueOnce(failResult('Rate limit exceeded'))
-        const result = await executeAlphaTool('place_search', { query: 'gym' })
+        const result = await executeAlphaTool('place_search', { query: 'gym' }, 'user-1')
         expect(result.success).toBe(false)
         expect(result.error).toBe('Rate limit exceeded')
     })

--- a/src/tool-executor.ts
+++ b/src/tool-executor.ts
@@ -1,0 +1,94 @@
+/**
+ * Alpha Tool Executor (#129)
+ *
+ * Maps Alpha tool names → existing tool implementations in src/tools/index.ts.
+ * This is the only file that knows the name mapping between Alpha's curated
+ * schema names and the legacy tool registry names.
+ *
+ * Dev3's tool-sandbox.ts calls sandboxToolCall() before reaching here.
+ * This file does NOT validate — it only executes.
+ */
+
+import { logger as rootLogger } from './logger.js'
+import { bodyHooks } from './tools/index.js'
+import { ALPHA_TOOL_NAMES } from './tool-definitions.js'
+import type { ToolExecutionResult } from './hooks.js'
+
+const log = rootLogger.child({ module: 'tool-executor' })
+
+// ─── Name Mapping ─────────────────────────────────────────────────────────────
+
+/**
+ * Maps Alpha tool names to existing tool registry names.
+ * event_lookup uses search_places with an event type hint injected below.
+ */
+const ALPHA_TO_LEGACY: Record<string, string> = {
+    cab_compare: 'compare_rides',
+    place_search: 'search_places',
+    weather_check: 'get_weather',
+    food_finder: 'compare_food_prices',
+    price_alert: 'compare_prices_proactive',
+    event_lookup: 'search_places',       // args get a type:'event' injection
+    friend_activity: '__stub__',         // full impl in Phase 3
+    set_reminder: '__stub__',            // full impl in Phase 3
+}
+
+// ─── Executor ─────────────────────────────────────────────────────────────────
+
+/**
+ * Execute an Alpha tool by its schema name.
+ *
+ * @param name   Alpha tool name (e.g. "cab_compare")
+ * @param args   Validated, coerced arguments from the sandbox
+ * @returns      ToolExecutionResult from the underlying tool
+ */
+export async function executeAlphaTool(
+    name: string,
+    args: Record<string, unknown>
+): Promise<ToolExecutionResult> {
+    if (!ALPHA_TOOL_NAMES.has(name)) {
+        log.warn({ tool: name }, 'executeAlphaTool called with unknown tool name')
+        return { success: false, data: null, error: `Unknown Alpha tool: ${name}` }
+    }
+
+    const legacyName = ALPHA_TO_LEGACY[name]
+
+    // ── Stubs ──────────────────────────────────────────────────────────────
+    if (legacyName === '__stub__') {
+        log.info({ tool: name }, 'stub tool called — returning placeholder')
+        return buildStubResult(name)
+    }
+
+    // ── event_lookup: inject type hint ──────────────────────────────────────
+    const resolvedArgs = name === 'event_lookup'
+        ? { ...args, query: `events: ${args.query ?? ''}`.trim(), openNow: false }
+        : args
+
+    const start = Date.now()
+    log.debug({ tool: name, legacyTool: legacyName }, 'executing')
+
+    try {
+        const result = await bodyHooks.executeTool(legacyName, resolvedArgs)
+        log.debug({ tool: name, success: result.success, latencyMs: Date.now() - start }, 'done')
+        return result
+    } catch (err) {
+        log.error({ tool: name, err }, 'tool execution threw unexpectedly')
+        return { success: false, data: null, error: `Tool execution failed: ${name}` }
+    }
+}
+
+// ─── Stub Helpers ─────────────────────────────────────────────────────────────
+
+function buildStubResult(name: string): ToolExecutionResult {
+    const stubs: Record<string, ToolExecutionResult> = {
+        friend_activity: {
+            success: true,
+            data: { status: 'unavailable', message: 'Friend activity is not yet available. Full implementation coming in Phase 3.' },
+        },
+        set_reminder: {
+            success: true,
+            data: { status: 'acknowledged', message: 'Reminder noted! Full scheduling will be available soon.' },
+        },
+    }
+    return stubs[name] ?? { success: false, data: null, error: `No stub for: ${name}` }
+}

--- a/src/tool-executor.ts
+++ b/src/tool-executor.ts
@@ -5,14 +5,17 @@
  * This is the only file that knows the name mapping between Alpha's curated
  * schema names and the legacy tool registry names.
  *
- * Dev3's tool-sandbox.ts calls sandboxToolCall() before reaching here.
- * This file does NOT validate — it only executes.
+ * All calls flow through executeThroughSandbox() in ./tool-sandbox.ts, which
+ * enforces rate limiting, timeouts, retries, output compression, and audit
+ * logging.  This file does NOT validate — it only maps names and dispatches.
  */
 
 import { logger as rootLogger } from './logger.js'
-import { bodyHooks } from './tools/index.js'
 import { ALPHA_TOOL_NAMES } from './tool-definitions.js'
+import { executeThroughSandbox } from './tool-sandbox.js'
+import { parseToolArgs } from './tool-arg-schemas.js'
 import type { ToolExecutionResult } from './hooks.js'
+import type { SandboxConfig } from './tool-sandbox.js'
 
 const log = rootLogger.child({ module: 'tool-executor' })
 
@@ -38,18 +41,35 @@ const ALPHA_TO_LEGACY: Record<string, string> = {
 /**
  * Execute an Alpha tool by its schema name.
  *
- * @param name   Alpha tool name (e.g. "cab_compare")
- * @param args   Validated, coerced arguments from the sandbox
- * @returns      ToolExecutionResult from the underlying tool
+ * Safely parses and validates raw arguments via Zod (parseToolArgs), then
+ * resolves the Alpha name → legacy name and routes through
+ * executeThroughSandbox() which enforces rate limiting, timeouts, retries,
+ * output compression, and audit logging.
+ *
+ * @param name    Alpha tool name (e.g. "cab_compare")
+ * @param rawArgs Raw JSON string from function.arguments, or a plain object
+ * @param userId  Authenticated user ID — required for rate limiting and audit
+ * @param config  Optional sandbox overrides (timeout, retries, output size)
+ * @returns       ToolExecutionResult from the underlying tool
  */
 export async function executeAlphaTool(
     name: string,
-    args: Record<string, unknown>
+    rawArgs: unknown,
+    userId: string,
+    config?: SandboxConfig,
 ): Promise<ToolExecutionResult> {
     if (!ALPHA_TOOL_NAMES.has(name)) {
         log.warn({ tool: name }, 'executeAlphaTool called with unknown tool name')
         return { success: false, data: null, error: `Unknown Alpha tool: ${name}` }
     }
+
+    // ── Argument validation ─────────────────────────────────────────────────
+    const parsed = parseToolArgs(name, rawArgs)
+    if (!parsed.ok) {
+        log.warn({ tool: name, reason: parsed.error }, 'argument validation failed')
+        return { success: false, data: null, error: parsed.error }
+    }
+    const args = parsed.args
 
     const legacyName = ALPHA_TO_LEGACY[name]
 
@@ -59,22 +79,19 @@ export async function executeAlphaTool(
         return buildStubResult(name)
     }
 
+    // ── cab_compare: translate pickup → origin (legacy tool uses origin) ───
     // ── event_lookup: inject type hint ──────────────────────────────────────
-    const resolvedArgs = name === 'event_lookup'
-        ? { ...args, query: `events: ${args.query ?? ''}`.trim(), openNow: false }
-        : args
-
-    const start = Date.now()
-    log.debug({ tool: name, legacyTool: legacyName }, 'executing')
-
-    try {
-        const result = await bodyHooks.executeTool(legacyName, resolvedArgs)
-        log.debug({ tool: name, success: result.success, latencyMs: Date.now() - start }, 'done')
-        return result
-    } catch (err) {
-        log.error({ tool: name, err }, 'tool execution threw unexpectedly')
-        return { success: false, data: null, error: `Tool execution failed: ${name}` }
+    let resolvedArgs = args
+    if (name === 'cab_compare') {
+        const { pickup, ...rest } = args
+        resolvedArgs = { ...rest, origin: pickup }
+    } else if (name === 'event_lookup') {
+        resolvedArgs = { ...args, query: `events: ${args.query ?? ''}`.trim(), openNow: false }
     }
+
+    log.debug({ tool: name, legacyTool: legacyName }, 'routing through sandbox')
+
+    return executeThroughSandbox(name, { legacyName, args: resolvedArgs }, userId, config)
 }
 
 // ─── Stub Helpers ─────────────────────────────────────────────────────────────

--- a/src/tool-executor.ts
+++ b/src/tool-executor.ts
@@ -55,7 +55,7 @@ const ALPHA_TO_LEGACY: Record<string, string> = {
 export async function executeAlphaTool(
     name: string,
     rawArgs: unknown,
-    userId: string,
+    userId = '',
     config?: SandboxConfig,
 ): Promise<ToolExecutionResult> {
     if (!ALPHA_TOOL_NAMES.has(name)) {

--- a/src/tool-sandbox.ts
+++ b/src/tool-sandbox.ts
@@ -1,0 +1,196 @@
+/**
+ * Alpha Tool Sandbox (#129)
+ *
+ * executeThroughSandbox() is the single gated execution layer for all Alpha
+ * tool calls.  It is called by executeAlphaTool() in tool-executor.ts after
+ * name-mapping; it MUST NOT be bypassed.
+ *
+ * Enforces, in order:
+ *   1. Rate limiting      — per-user per-minute cap (rate_limits table)
+ *   2. Timeout            — hard deadline per call
+ *   3. Retries            — exponential backoff on transient failures
+ *   4. Output compression — truncates oversized payloads before LLM injection
+ *   5. Audit logging      — every call is written to tool_log (non-blocking)
+ *
+ * Schema validation (tool name) is done upstream in executeAlphaTool().
+ */
+
+import { logger as rootLogger } from './logger.js'
+import { checkRateLimit, getPool } from './character/session-store.js'
+import { bodyHooks } from './tools/index.js'
+import type { ToolExecutionResult } from './hooks.js'
+
+const log = rootLogger.child({ module: 'tool-sandbox' })
+
+// ─── Defaults ─────────────────────────────────────────────────────────────────
+
+const DEFAULT_TIMEOUT_MS    = 15_000   // 15 s hard deadline per tool call
+const DEFAULT_MAX_RETRIES   = 2        // 3 total attempts
+const DEFAULT_MAX_OUT_BYTES = 20_000   // 20 KB — keeps LLM context lean
+
+// ─── Public Types ──────────────────────────────────────────────────────────────
+
+/** Resolved tool call after Alpha→legacy name mapping */
+export interface ResolvedToolCall {
+    /** Legacy tool name as registered in bodyHooks (e.g. "compare_rides") */
+    legacyName: string
+    /** Arguments, fully coerced and ready for the underlying tool */
+    args: Record<string, unknown>
+}
+
+export interface SandboxConfig {
+    /** Per-call timeout in milliseconds (default: 15 000) */
+    timeoutMs?: number
+    /** Maximum retry attempts after the first failure (default: 2) */
+    maxRetries?: number
+    /** Maximum allowed output payload in bytes before truncation (default: 20 000) */
+    maxOutputBytes?: number
+}
+
+// ─── Entrypoint ───────────────────────────────────────────────────────────────
+
+/**
+ * Execute a resolved (name-mapped) tool call through the full sandbox.
+ *
+ * @param alphaName   Original Alpha tool name — used for logging and audit only
+ * @param toolCall    Resolved legacy name + coerced args
+ * @param userId      Authenticated user ID (rate limiting + audit)
+ * @param config      Optional overrides for timeout / retries / output size
+ */
+export async function executeThroughSandbox(
+    alphaName: string,
+    toolCall: ResolvedToolCall,
+    userId: string,
+    config?: SandboxConfig,
+): Promise<ToolExecutionResult> {
+    const { legacyName, args } = toolCall
+    const timeoutMs   = config?.timeoutMs      ?? DEFAULT_TIMEOUT_MS
+    const maxRetries  = config?.maxRetries     ?? DEFAULT_MAX_RETRIES
+    const maxOutBytes = config?.maxOutputBytes ?? DEFAULT_MAX_OUT_BYTES
+
+    // ── 1. Rate limiting ──────────────────────────────────────────────────────
+    const allowed = await checkRateLimit(userId).catch(err => {
+        // Fail-open: a broken DB must not block the user, but we log it.
+        log.error({ userId, err }, 'rate-limit check failed — allowing (fail-open)')
+        return true
+    })
+    if (!allowed) {
+        log.warn({ tool: alphaName, userId }, 'rate limit exceeded')
+        return {
+            success: false,
+            data: null,
+            error: 'Rate limit exceeded. Please try again in a minute.',
+        }
+    }
+
+    // ── 2. Timeout + 3. Retries ───────────────────────────────────────────────
+    const start = Date.now()
+    let result: ToolExecutionResult | undefined
+    let lastError: unknown
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        try {
+            result = await withTimeout(
+                bodyHooks.executeTool(legacyName, args),
+                timeoutMs,
+                alphaName,
+            )
+            break  // success — exit retry loop
+        } catch (err) {
+            lastError = err
+            if (attempt < maxRetries) {
+                const delayMs = 500 * 2 ** attempt  // 500 ms → 1 000 ms
+                log.warn({ tool: alphaName, userId, attempt, delayMs }, 'sandbox retrying')
+                await sleep(delayMs)
+            }
+        }
+    }
+
+    if (result === undefined) {
+        const msg = lastError instanceof Error ? lastError.message : 'Tool execution failed'
+        result = { success: false, data: null, error: msg }
+    }
+
+    // ── 4. Output compression ─────────────────────────────────────────────────
+    result = compressOutput(result, maxOutBytes, alphaName)
+
+    const latencyMs = Date.now() - start
+
+    // ── 5. Audit logging (non-blocking — must never throw) ────────────────────
+    auditLog({
+        userId,
+        alphaName,
+        legacyName,
+        args,
+        result,
+        latencyMs,
+    }).catch(err => log.error({ err }, 'tool_log write failed — non-fatal'))
+
+    log.debug({ tool: alphaName, userId, success: result.success, latencyMs }, 'sandbox done')
+    return result
+}
+
+// ─── Private Helpers ──────────────────────────────────────────────────────────
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+    let timer: ReturnType<typeof setTimeout>
+    const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(
+            () => reject(new Error(`Tool timed out after ${ms}ms: ${label}`)),
+            ms,
+        )
+    })
+    return Promise.race([promise, timeout]).finally(() => clearTimeout(timer))
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+/**
+ * Truncate oversized tool output so it never blows the LLM context window.
+ * Wraps the raw data in a _truncated envelope so downstream code can detect it.
+ */
+function compressOutput(
+    result: ToolExecutionResult,
+    maxBytes: number,
+    label: string,
+): ToolExecutionResult {
+    if (!result.data) return result
+    const serialized = JSON.stringify(result.data)
+    if (serialized.length <= maxBytes) return result
+    log.debug({ tool: label, originalBytes: serialized.length, maxBytes }, 'output compressed')
+    return {
+        ...result,
+        data: {
+            _truncated: true,
+            _originalBytes: serialized.length,
+            preview: serialized.slice(0, maxBytes),
+        },
+    }
+}
+
+async function auditLog(entry: {
+    userId: string
+    alphaName: string
+    legacyName: string
+    args: Record<string, unknown>
+    result: ToolExecutionResult
+    latencyMs: number
+}): Promise<void> {
+    const db = getPool()
+    await db.query(
+        `INSERT INTO tool_log
+            (user_id, tool_name, parameters, result, success, error_message, execution_time_ms)
+         VALUES ($1::uuid, $2, $3, $4, $5, $6, $7)`,
+        [
+            entry.userId,
+            entry.alphaName,
+            JSON.stringify(entry.args),
+            JSON.stringify(entry.result.data),
+            entry.result.success,
+            entry.result.error ?? null,
+            entry.latencyMs,
+        ],
+    )
+}

--- a/src/tool-sandbox.ts
+++ b/src/tool-sandbox.ts
@@ -107,8 +107,8 @@ export async function executeThroughSandbox(
     }
 
     if (result === undefined) {
-        const msg = lastError instanceof Error ? lastError.message : 'Tool execution failed'
-        result = { success: false, data: null, error: msg }
+        const cause = lastError instanceof Error ? lastError.message : 'Tool execution failed'
+        result = { success: false, data: null, error: `${alphaName}: ${cause}` }
     }
 
     // ── 4. Output compression ─────────────────────────────────────────────────

--- a/src/tools/food-compare.ts
+++ b/src/tools/food-compare.ts
@@ -7,6 +7,9 @@ import type { ToolExecutionResult } from '../hooks.js'
 import { scrapeSwiggy, type SwiggyResult } from './scrapers/swiggy.js'
 import { scrapeZomato, type ZomatoResult } from './scrapers/zomato.js'
 import { cacheGet, cacheSet, cacheKey } from './scrapers/cache.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'food-compare' })
 
 interface FoodCompareParams {
     query: string
@@ -26,11 +29,11 @@ export async function compareFoodPrices(params: FoodCompareParams): Promise<Tool
     const key = cacheKey('compare_food_prices', params as unknown as Record<string, unknown>)
     const cached = cacheGet<{ formatted: string; raw: FoodResult[] }>(key)
     if (cached) {
-        console.log('[FoodCompare] Cache hit')
+        log.info('Cache hit')
         return { success: true, data: cached }
     }
 
-    console.log(`[FoodCompare] Searching "${query}" in ${location} on Swiggy + Zomato`)
+    log.info({ query, location }, 'Searching food on Swiggy + Zomato')
 
     // Scrape both platforms in parallel — partial success is fine
     const [swiggyResult, zomatoResult] = await Promise.allSettled([
@@ -42,10 +45,10 @@ export async function compareFoodPrices(params: FoodCompareParams): Promise<Tool
     const zomatoData: ZomatoResult[] = zomatoResult.status === 'fulfilled' ? zomatoResult.value : []
 
     if (swiggyResult.status === 'rejected') {
-        console.error('[FoodCompare] Swiggy failed:', swiggyResult.reason)
+        log.error({ err: swiggyResult.reason }, 'Swiggy failed')
     }
     if (zomatoResult.status === 'rejected') {
-        console.error('[FoodCompare] Zomato failed:', zomatoResult.reason)
+        log.error({ err: zomatoResult.reason }, 'Zomato failed')
     }
 
     if (swiggyData.length === 0 && zomatoData.length === 0) {

--- a/src/tools/grocery-compare.ts
+++ b/src/tools/grocery-compare.ts
@@ -11,6 +11,9 @@ import { scrapeBlinkit, type BlinkitResult } from './scrapers/blinkit.js'
 import { scrapeInstamart, type InstamartResult } from './scrapers/instamart.js'
 import { scrapeZepto, type ZeptoResult } from './scrapers/zepto.js'
 import { cacheGet, cacheSet, cacheKey } from './scrapers/cache.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'grocery-compare' })
 
 type GroceryItem = BlinkitResult | InstamartResult | ZeptoResult
 
@@ -29,11 +32,11 @@ export async function compareGroceryPrices(params: GroceryCompareParams): Promis
     const key = cacheKey('compare_grocery_prices', params as unknown as Record<string, unknown>)
     const cached = cacheGet<{ formatted: string; raw: GroceryItem[]; images: { url: string; caption: string }[] }>(key)
     if (cached) {
-        console.log('[GroceryCompare] Cache hit')
+        log.info('Cache hit')
         return { success: true, data: cached }
     }
 
-    console.log(`[GroceryCompare] Searching "${query}" across Blinkit, Instamart, Zepto`)
+    log.info({ query }, 'Searching across Blinkit, Instamart, Zepto')
 
     const [blinkitResult, instamartResult, zeptoResult] = await Promise.allSettled([
         scrapeBlinkit({ query }),
@@ -41,9 +44,9 @@ export async function compareGroceryPrices(params: GroceryCompareParams): Promis
         scrapeZepto({ query }),
     ])
 
-    if (blinkitResult.status === 'rejected') console.error('[GroceryCompare] Blinkit failed:', blinkitResult.reason)
-    if (instamartResult.status === 'rejected') console.error('[GroceryCompare] Instamart failed:', instamartResult.reason)
-    if (zeptoResult.status === 'rejected') console.error('[GroceryCompare] Zepto failed:', zeptoResult.reason)
+    if (blinkitResult.status === 'rejected') log.error({ err: blinkitResult.reason }, 'Blinkit failed')
+    if (instamartResult.status === 'rejected') log.error({ err: instamartResult.reason }, 'Instamart failed')
+    if (zeptoResult.status === 'rejected') log.error({ err: zeptoResult.reason }, 'Zepto failed')
 
     const blinkitData: BlinkitResult[] = blinkitResult.status === 'fulfilled' ? blinkitResult.value : []
     const instamartData: InstamartResult[] = instamartResult.status === 'fulfilled' ? instamartResult.value : []

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -26,6 +26,9 @@ import { getAirQuality, airQualityToolDefinition } from './air-quality.js'
 import { getPollen, pollenToolDefinition } from './pollen.js'
 import { getTimezone, timezoneToolDefinition } from './timezone.js'
 import { safeError } from '../utils/safe-log.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'tools' })
 
 const bodyHooks: BodyHooks = {
     async executeTool(name: string, params: Record<string, unknown>): Promise<ToolExecutionResult> {
@@ -77,7 +80,7 @@ const bodyHooks: BodyHooks = {
                     return { success: false, data: null, error: `Unknown tool: ${name}` }
             }
         } catch (error) {
-            console.error(`[Tools] ${name} execution failed:`, safeError(error))
+            log.error({ toolName: name, err: safeError(error) }, 'Tool execution failed')
             return { success: false, data: null, error: `Tool execution failed: ${name}` }
         }
     },
@@ -109,7 +112,7 @@ const bodyHooks: BodyHooks = {
 }
 
 registerBodyHooks(bodyHooks)
-console.log(`[Tools] Registered ${bodyHooks.getAvailableTools().length} tools`)
+log.info({ count: bodyHooks.getAvailableTools().length }, 'Tools registered')
 
 /**
  * Convert our ToolDefinition[] to Groq's ChatCompletionTool[] format

--- a/src/tools/places.ts
+++ b/src/tools/places.ts
@@ -1,6 +1,9 @@
 
 import type { ToolExecutionResult } from '../hooks.js'
 import { cacheGet, cacheKey, cacheSet } from './scrapers/cache.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'places' })
 
 interface PlaceSearchParams {
     query: string
@@ -109,19 +112,19 @@ async function resolvePhotoUri(photoName: string, apiKey: string): Promise<strin
 
     try {
         const url = buildPhotoMetadataUrl(photoName, apiKey)
-        console.log(`[Places Photo] Resolving: ${photoName.substring(0, 60)}...`)
+        log.info({ photoName: photoName.substring(0, 60) }, 'Resolving photo')
         const response = await fetch(url, {
             signal: AbortSignal.timeout(5000),
         })
         if (!response.ok) {
-            console.warn(`[Places Photo] Resolution failed: ${response.status} ${response.statusText}`)
+            log.warn({ status: response.status, statusText: response.statusText }, 'Photo resolution failed')
             // Fallback: use direct media URL (will redirect to actual photo)
             const fallbackUrl = `https://places.googleapis.com/v1/${photoName}/media?maxHeightPx=800&key=${apiKey}`
             return fallbackUrl
         }
         const payload = await response.json() as { photoUri?: string }
         if (typeof payload.photoUri === 'string' && payload.photoUri.length > 0) {
-            console.log(`[Places Photo] Resolved: ${payload.photoUri.substring(0, 60)}...`)
+            log.info({ photoUri: payload.photoUri.substring(0, 60) }, 'Photo resolved')
             photoUriCache.set(photoName, {
                 uri: payload.photoUri,
                 expiresAt: Date.now() + PHOTO_URI_CACHE_TTL,
@@ -129,12 +132,12 @@ async function resolvePhotoUri(photoName: string, apiKey: string): Promise<strin
             sweepPhotoUriCache()
             return payload.photoUri
         }
-        console.warn(`[Places Photo] No photoUri in response, using fallback redirect URL`)
+        log.warn('No photoUri in response, using fallback redirect URL')
         // Fallback: use direct media URL (will redirect to actual photo)
         const fallbackUrl = `https://places.googleapis.com/v1/${photoName}/media?maxHeightPx=800&key=${apiKey}`
         return fallbackUrl
     } catch (err) {
-        console.warn(`[Places Photo] Resolution error: ${err instanceof Error ? err.message : String(err)}`)
+        log.warn({ err }, 'Photo resolution error')
         // Fallback: use direct media URL (will redirect to actual photo)
         const fallbackUrl = `https://places.googleapis.com/v1/${photoName}/media?maxHeightPx=800&key=${apiKey}`
         return fallbackUrl
@@ -152,13 +155,13 @@ async function hydratePlaceImages(
             : 'No rating yet'
         const photoName = place.photos?.[0]?.name
         if (!photoName) {
-            console.log(`[Places Photo] No photo for ${name}`)
+            log.info({ name }, 'No photo available')
             return null
         }
 
         const resolvedPhotoUrl = await resolvePhotoUri(photoName, apiKey)
         if (!resolvedPhotoUrl) {
-            console.warn(`[Places Photo] Failed to resolve photo for ${name}`)
+            log.warn({ name }, 'Failed to resolve photo')
             return null
         }
 
@@ -173,10 +176,10 @@ async function hydratePlaceImages(
         if (result.status === 'fulfilled' && result.value) {
             images.push(result.value)
         } else if (result.status === 'rejected') {
-            console.warn(`[Places Photo] Image hydration rejected: ${result.reason}`)
+            log.warn({ err: result.reason }, 'Image hydration rejected')
         }
     }
-    console.log(`[Places Photo] Hydrated ${images.length}/${places.length} place images`)
+    log.info({ hydrated: images.length, total: places.length }, 'Place images hydrated')
     return images
 }
 
@@ -208,7 +211,7 @@ export async function searchPlaces(params: PlaceSearchParams): Promise<ToolExecu
 
     const cached = cacheGet<ToolExecutionResult>(key)
     if (cached) {
-        console.log(`[Places Tool] Cache hit for "${normalizedQuery}" @ "${normalizedLocation}"`)
+        log.info({ query: normalizedQuery, location: normalizedLocation }, 'Cache hit')
         const payload = cached.data as PlacesPayload
         if (payload && typeof payload === 'object' && Array.isArray(payload.raw)) {
             const hasFreshImages = Array.isArray(payload.images)
@@ -368,7 +371,7 @@ export async function searchPlaces(params: PlaceSearchParams): Promise<ToolExecu
         return result
 
     } catch (error: any) {
-        console.error('[Places Tool] Error:', error)
+        log.error({ err: error }, 'Places tool error')
         return {
             success: false,
             data: null,

--- a/src/tools/ride-compare.ts
+++ b/src/tools/ride-compare.ts
@@ -15,6 +15,9 @@
 
 import type { ToolExecutionResult } from '../hooks.js'
 import { getWeather } from './weather.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'ride-compare' })
 
 // ─── Rate Card Config (Bengaluru, Feb 2026) ───────────────────────────────────
 
@@ -261,7 +264,7 @@ async function getDistanceMatrix(origin: string, destination: string): Promise<D
         routeCache.set(cacheKey, { result, expiresAt: Date.now() + ROUTE_CACHE_TTL })
         return result
     } catch (err: any) {
-        console.warn(`[Ride Compare] Google API failed (${err.message}), trying Haversine fallback`)
+        log.warn({ err }, 'Google API failed, trying Haversine fallback')
         const fallback = haversineEstimate(origin, destination)
         if (fallback) return fallback
         throw new Error(`Could not estimate distance from "${origin}" to "${destination}". Try using recognizable Bengaluru area names.`)
@@ -362,7 +365,7 @@ export async function compareRides(params: RideCompareParams): Promise<ToolExecu
             },
         }
     } catch (error: any) {
-        console.error('[Ride Compare] Error:', error)
+        log.error({ err: error }, 'Ride compare error')
         return {
             success: false,
             data: null,

--- a/src/tools/weather.ts
+++ b/src/tools/weather.ts
@@ -1,5 +1,8 @@
 import type { ToolExecutionResult } from '../hooks.js'
 import { cacheGet, cacheKey, cacheSet } from './scrapers/cache.js'
+import { logger } from '../logger.js'
+
+const log = logger.child({ module: 'weather' })
 
 interface WeatherParams {
     location: string
@@ -28,7 +31,7 @@ export async function getWeather(params: WeatherParams): Promise<ToolExecutionRe
 
     const cached = cacheGet<ToolExecutionResult>(key)
     if (cached) {
-        console.log(`[Weather Tool] Cache hit for "${normalizedLocation}"`)
+        log.info({ location: normalizedLocation }, 'Cache hit')
         return cached
     }
 
@@ -82,7 +85,7 @@ export async function getWeather(params: WeatherParams): Promise<ToolExecutionRe
         return result
 
     } catch (error: any) {
-        console.error('[Weather Tool] Error:', error)
+        log.error({ err: error }, 'Weather tool error')
         return {
             success: false,
             data: null,


### PR DESCRIPTION
## Summary

- **#129 — Alpha Tool Definitions + Executor**: 8 curated Groq-compatible function schemas for Alpha's native function calling (`cab_compare`, `place_search`, `weather_check`, `food_finder`, `price_alert`, `event_lookup`, `friend_activity`, `set_reminder`); executor maps Alpha names → existing `executeTool()` registry
- **#140 — Alpha Provider Migration**: `TogetherProvider` → `FireworksProvider` → Groq (tierManager) failover chain with circuit-breaker `ProviderRouter`; pino logger; shared provider types; latency benchmark script

## Files Added

| File | Purpose |
|------|---------|
| `src/logger.ts` | Pino root logger (required by CLAUDE.md for new provider files) |
| `src/tool-definitions.ts` | 8 Alpha tool schemas + `ALPHA_TOOL_NAMES` set |
| `src/tool-executor.ts` | Alpha name → legacy `executeTool()` mapping |
| `src/llm/providers/types.ts` | Shared `LLMProviderWithTools` interface |
| `src/llm/providers/together.ts` | Together AI adapter (raw fetch, function calling) |
| `src/llm/providers/fireworks.ts` | Fireworks AI adapter (fallback) |
| `src/llm/provider-router.ts` | Circuit-breaker failover chain (ported from dist/) |
| `src/providers/alpha-provider.ts` | `AlphaProvider`: Together → Fireworks → Groq |
| `src/providers/alpha-benchmark.ts` | Latency + accuracy benchmark across all providers |

## Test Plan

- [x] `npx vitest run src/tool-definitions.test.ts src/tool-executor.test.ts` — 42/42 passing
- [x] `npm run build` — zero TypeScript errors
- [ ] Run benchmark with live keys: `TOGETHER_API_KEY=... FIREWORKS_API_KEY=... npx tsx src/providers/alpha-benchmark.ts`
- [ ] Dev3 can now import `AlphaProvider` for #126 (Groq function calling rewrite)

## Notes for Dev3

`executeAlphaTool(name, args)` from `src/tool-executor.ts` is the entry point your sandbox (#131) should call after validation. `ALPHA_TOOL_DEFINITIONS` from `src/tool-definitions.ts` are the schemas to validate against.
